### PR TITLE
fix(ci): untrack .xcode.env.local so build-ios uses runner's node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,12 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      # Xcode 26.5 lazy-mounts the Metal toolchain, which breaks TOOLCHAIN_DIR
+      # resolution in LIBRARY_SEARCH_PATHS and loses libswiftCompatibility56.a.
+      # Pin to 26.4, the version the example is verified against.
+      - name: Select Xcode 26.4
+        run: sudo xcode-select -s /Applications/Xcode_26.4.app
+
       - name: Cache turborepo for iOS
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,12 +112,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      # Xcode 26.5 lazy-mounts the Metal toolchain, which breaks TOOLCHAIN_DIR
-      # resolution in LIBRARY_SEARCH_PATHS and loses libswiftCompatibility56.a.
-      # Pin to 26.4, the version the example is verified against.
-      - name: Select Xcode 26.4
-        run: sudo xcode-select -s /Applications/Xcode_26.4.app
-
       - name: Cache turborepo for iOS
         uses: actions/cache@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
+**/.xcode.env.local
 
 # Android/IJ
 #

--- a/example/ios/.xcode.env.local
+++ b/example/ios/.xcode.env.local
@@ -1,1 +1,0 @@
-export NODE_BINARY=/Users/teo/.nvm/versions/node/v24.11.0/bin/node

--- a/example/ios/CacheVideoExample.xcodeproj/project.pbxproj
+++ b/example/ios/CacheVideoExample.xcodeproj/project.pbxproj
@@ -628,7 +628,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(SDKROOT)/usr/lib/swift\"",
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -701,7 +701,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(SDKROOT)/usr/lib/swift\"",
-					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "build:android": "cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
-    "build:ios": "cd ios && xcodebuild -workspace CacheVideoExample.xcworkspace -scheme CacheVideoExample -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO"
+    "build:ios": "cd ios && xcodebuild -workspace CacheVideoExample.xcworkspace -scheme CacheVideoExample -configuration Debug -sdk iphonesimulator ARCHS=arm64 CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO"
   },
   "dependencies": {
     "react": "19.1.4",


### PR DESCRIPTION
## Why

The `build-ios` CI job had been failing since the new-arch migration (42d98d4). It turned out to be **two stacked problems**, neither of them the suspected Xcode 26.5 toolchain regression (the `libclang` explicit-modules notes were noise):

### 1. Committed `.xcode.env.local` with a machine-local node path

```
Node found at: /Users/teo/.nvm/versions/node/v24.11.0/bin/node
Script-….sh: line 9: /Users/teo/.nvm/versions/node/v24.11.0/bin/node: No such file or directory
```

React Native says this file must never be versioned. Fix: `git rm --cached` + gitignore `**/.xcode.env.local`. The versioned `.xcode.env` already resolves node via `command -v node`.

### 2. `$(TOOLCHAIN_DIR)` resolves to an unmounted Metal-toolchain cryptex on the runners

With problem 1 fixed, the app dylib failed to link:

```
ld: warning: search path '/var/run/com.apple.security.cryptexd/mnt/com.apple.MobileAsset.MetalToolchain-…/Metal.xctoolchain/usr/lib/swift/iphonesimulator' not found
Undefined symbols: "__swift_FORCE_LOAD_$_swiftCompatibility56", referenced from libreact-native-video.a
```

On GitHub's macos-26 images this reproduces on **both** Xcode 26.5 and 26.4.1 (a 26.4 pin was tried and reverted): `$(TOOLCHAIN_DIR)` in the app's legacy `LIBRARY_SEARCH_PATHS` points at a Metal-toolchain mount that doesn't exist on CI, so the ObjC-only app target loses the directory holding `libswiftCompatibility56.a` (force-loaded by react-native-video's Swift objects). Fix: anchor the search path to `$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME)`.

Also: `build:ios` now builds `ARCHS=arm64` only (Xcode 26 and the runners are Apple-Silicon-only; halves build time).

## Result

`build-ios` is green: https://github.com/nguyenvanphituoc/react-native-cache-video/actions/runs/29559017620/job/87817288451

🤖 Generated with [Claude Code](https://claude.com/claude-code)