### PR TITLE
chore(ci): Claude as sole PR reviewer — best-practice config [skip-review]

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# CodeRabbit is disabled for this repository — Claude Code Review
+# (.github/workflows/claude-code-review.yml) is the source of PR review.
+# To remove CodeRabbit entirely, uninstall the GitHub App:
+# repo Settings → Integrations → GitHub Apps → CodeRabbit → Configure/Uninstall.
+reviews:
+  auto_review:
+    enabled: false
+chat:
+  auto_reply: false

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,28 +2,37 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    types: [opened, synchronize, ready_for_review]
+    # Review only code-bearing changes; docs/config churn is CI-checked, not reviewed
+    paths:
+      - 'src/**'
+      - 'ios/**'
+      - 'android/**'
+      - 'plugin/src/**'
+      - 'example/**'
+      - 'example-expo/**'
+      - 'package.json'
+      - '*.podspec'
+
+# One review per PR at a time; a new push cancels the superseded run (cost control)
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip drafts, bot-authored PRs, and PRs opting out via [skip-review]
+    if: |
+      !github.event.pull_request.draft &&
+      github.event.pull_request.user.type != 'Bot' &&
+      !contains(github.event.pull_request.title, '[skip-review]')
 
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write # post/update the review comment
       issues: read
-      id-token: write
+      id-token: write # required for OAuth token exchange
 
     steps:
       - name: Checkout repository
@@ -39,6 +48,14 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # One always-visible summary comment, updated in place on each push.
+          # Trade-off: sticky mode replaces inline diff comments with the single summary.
+          use_sticky_comment: true
+          # Sanity-check inline findings through a fast model before posting (fewer false positives)
+          classify_inline_comments: true
+          include_fix_links: true
+          # Review severity/scope tuning lives in REVIEW.md at the repo root.
+          # NOTE: changes to this file only take effect after merging to main —
+          # the action refuses to run a pull_request-triggered workflow whose
+          # file differs from the default branch (anti-tampering).
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,12 @@ on:
 jobs:
   claude:
     if: |
+      (github.actor != 'claude[bot]') && (
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,43 @@
+# Code Review Guidelines
+
+Guidance for automated code review (Claude Code Review) on this repository — a React
+Native library (`react-native-cache-video`) shipping TypeScript + iOS (ObjC++) +
+Android (Kotlin) with old-arch and new-arch (TurboModule) support.
+
+## Important (report these)
+
+- Breaking changes to the public API (`src/index.tsx` exports, TurboModule spec
+  `src/NativeCacheVideoHttpProxy.ts`, event names `RNCV_*` / `HLS_CACHING_RESTART`)
+- iOS/Android behavior divergence (the two native servers must stay contract-identical:
+  `spec/contracts` semantics — start result, port binding, repeat-start)
+- Old-arch/new-arch compatibility regressions (codegen spec changes, `__turboModuleProxy`
+  selection, Expo config plugin)
+- Cache-integrity bugs: anything that could serve an unverified/partial file, register a
+  cache entry before verification, or resurrect orphaned `.part` files
+- Server-lifecycle races: readiness state vs actual native server state, event emission
+  before confirmed start, retry/port handling
+- Memory leaks (native server instances, event listeners, subscribers) and unhandled
+  promise rejections
+- Security: no cleartext exposure beyond the documented localhost proxy, no path
+  traversal via cache keys, no secrets
+
+## Nit (mention briefly, don't block)
+
+- Naming/style not enforced by eslint/prettier
+- Refactoring opportunities, test readability
+- Comment gaps
+
+## Do not report
+
+- Formatting/lint issues (CI runs eslint + prettier; lefthook enforces locally)
+- Generated/compiled output: `lib/`, `plugin/build/`, `android/build/`, codegen artifacts
+- Lockfiles, `docs/**`, `*.md` content style
+- Pre-existing warnings explicitly tracked in `docs/shapeup-sdlc/*/round-ledger.md` or
+  the discovery ledger
+
+## Context worth knowing
+
+- Tests are jest with manual mocks under `src/__mock__/` (no real native modules, no
+  React renderer); mock knobs are the intended seams — don't flag them as test smells
+- `example/` is RN CLI, `example-expo/` is Expo SDK; only `example/` carries the
+  readiness-indicator demo by design (scope decision D3)


### PR DESCRIPTION
Makes Claude Code Review the single review source with the configuration recommended by the claude-code-action docs:

- **claude-code-review.yml**: path filters (code-bearing paths only), skip for drafts / bot PRs / `[skip-review]` titles, per-PR concurrency with cancellation, `pull-requests: write` + `id-token: write` permissions, **sticky summary comment** (always visible even with zero findings, updated in place on each push), `classify_inline_comments`, `include_fix_links`.
- **claude.yml**: `claude[bot]` self-trigger guard (no bot loops).
- **REVIEW.md**: repo-tuned severity guidance (Important vs Nit vs do-not-report) for this RN library.
- **.coderabbit.yaml**: CodeRabbit auto-review disabled — full app uninstall is a repo-settings action.

Note: per the action's anti-tamper validation, `pull_request`-triggered Claude workflows only run when the workflow file matches the default branch — so these changes activate once this PR merges. PR #13 was reverted to the main version of the workflow for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)