### PR TITLE
chore(ci): remove review diagnostics [skip-review]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,10 +65,6 @@ jobs:
           # terminal-only (the exact failure seen on PR #13's runs).
           claude_args: |
             --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep"
-          # TEMP DIAGNOSTIC: expose the full execution transcript in the run log
-          # to identify the recurring silent permission denial + early exit.
-          # Remove once the review posts comments reliably.
-          show_full_output: true
           # Review severity/scope tuning lives in REVIEW.md at the repo root.
           # NOTE: changes to this file only take effect after merging to main —
           # the action refuses to run a pull_request-triggered workflow whose


### PR DESCRIPTION
Removes the temporary show_full_output flag — the review now posts its summary comment (see claude[bot] on PR #13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)