### PR TITLE
ci: keep verbose OIDC logging on publish, drop the diagnostic scaffolding

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,24 +62,6 @@ jobs:
             exit 1
           fi
 
-      - name: Diagnose OIDC availability
-        run: |
-          echo "npm: $(npm --version)"
-          # Presence only — never echo the token itself.
-          if [ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]; then
-            echo "ACTIONS_ID_TOKEN_REQUEST_URL: PRESENT"
-          else
-            echo "ACTIONS_ID_TOKEN_REQUEST_URL: ABSENT  <-- OIDC not available to this job"
-          fi
-          if [ -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ]; then
-            echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: PRESENT (len ${#ACTIONS_ID_TOKEN_REQUEST_TOKEN})"
-          else
-            echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: ABSENT"
-          fi
-          echo "registry: $(npm config get registry)"
-          echo "whoami (expected to fail without OIDC):"
-          npm whoami || true
-
       - name: Build the publishable artifact
         run: yarn prepare
 
@@ -93,7 +75,7 @@ jobs:
         # cause. The `oidc` verbose lines name it exactly — the registry's own
         # message for a refused exchange, a missing token in the response, or
         # skipped-for-permissions.
-        run: npm publish --provenance --access public --loglevel verbose
+        run: npm publish --access public --loglevel verbose
 
       - name: Verify what the registry now serves
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,9 +85,15 @@ jobs:
 
       - name: Publish to npm
         # No NODE_AUTH_TOKEN / .npmrc — OIDC provides the credential.
-        # --provenance publishes a signed attestation linking the tarball to
-        # this workflow run, which is the point of trusting the repo.
-        run: npm publish --provenance --access public
+        #
+        # --loglevel verbose is deliberate and worth keeping: npm's oidc()
+        # helper NEVER throws. Every failure path returns undefined and logs
+        # only at verbose/silly, so a refused token exchange surfaces as a bare
+        # ENEEDAUTH ("you need to run npm login") with no hint of the real
+        # cause. The `oidc` verbose lines name it exactly — the registry's own
+        # message for a refused exchange, a missing token in the response, or
+        # skipped-for-permissions.
+        run: npm publish --provenance --access public --loglevel verbose
 
       - name: Verify what the registry now serves
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,24 @@ jobs:
             exit 1
           fi
 
+      - name: Diagnose OIDC availability
+        run: |
+          echo "npm: $(npm --version)"
+          # Presence only — never echo the token itself.
+          if [ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]; then
+            echo "ACTIONS_ID_TOKEN_REQUEST_URL: PRESENT"
+          else
+            echo "ACTIONS_ID_TOKEN_REQUEST_URL: ABSENT  <-- OIDC not available to this job"
+          fi
+          if [ -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ]; then
+            echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: PRESENT (len ${#ACTIONS_ID_TOKEN_REQUEST_TOKEN})"
+          else
+            echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: ABSENT"
+          fi
+          echo "registry: $(npm config get registry)"
+          echo "whoami (expected to fail without OIDC):"
+          npm whoami || true
+
       - name: Build the publishable artifact
         run: yarn prepare
 


### PR DESCRIPTION
Follow-up to #22, after **0.5.0 published successfully** via trusted publishing.

Net change to `publish.yml` is +9/−3 across three commits (the middle two add scaffolding, the last removes it).

## What stays: `--loglevel verbose`

This is the one change worth keeping, and the reason is specific. npm's `lib/utils/oidc.js` is documented as *"intended to never throw"* — every failure path does `return undefined` and logs only at `verbose`/`silly`:

```js
} catch (error) {
  log.verbose('oidc', `Failed token exchange request with body message: ${error?.body?.message || 'Unknown error'}`)
  return undefined
}
```

npm then continues **with no credential** and reports a bare `ENEEDAUTH` — *"You need to authorize this machine using `npm login`"* — no matter what actually went wrong. That message is actively misleading in CI, where `npm login` is not the answer and never will be.

Three runs failed that way before verbose logging showed the real cause in one line:

```
POST 404 …/oidc/token/exchange/package/react-native-cache-video
npm verbose oidc Failed token exchange request with body message:
      OIDC token exchange error - package not found
```

…i.e. no trusted-publisher record on npmjs yet. Once configured, the same endpoint returned **201** and the publish went through.

## What goes

- **The temporary `Diagnose OIDC availability` step** — it proved the runner *was* providing `ACTIONS_ID_TOKEN_REQUEST_URL`/`_TOKEN`, which ruled out a GitHub permissions problem and redirected the investigation to the registry. Done its job.
- **`--provenance`** — [the docs](https://docs.npmjs.com/trusted-publishers) state provenance is automatic under trusted publishing, and the 0.5.0 run confirmed it: the attestation was signed and written to the sigstore transparency log, and the registry now reports a SLSA provenance predicate for `0.5.0`.

## Verified

```
npm view react-native-cache-video version   -> 0.5.0
dist-tags                                   -> { latest: '0.5.0' }
dist.attestations                           -> predicateType: https://slsa.dev/provenance/v1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9KW4gfdm8gRQrwKvAG3AR