### PR TITLE
0.5.1 hardening: cache-key policy, RNCV_CACHE_STATUS export, ranged Content-Range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,67 @@ jobs:
         run: |
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
+  build-android-expo:
+    runs-on: ubuntu-latest
+    env:
+      TURBO_CACHE_DIR: .turbo/android-expo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect relevant changes
+        if: github.event_name == 'pull_request'
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            relevant:
+              - 'src/**'
+              - 'example-expo/**'
+
+      - name: Setup
+        if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
+        uses: ./.github/actions/setup
+
+      - name: Cache turborepo for Android (Expo)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.TURBO_CACHE_DIR }}
+          key: ${{ runner.os }}-turborepo-android-expo-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-turborepo-android-expo-
+
+      - name: Install JDK
+        if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Finalize Android SDK
+        if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
+        run: |
+          /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
+
+      - name: Expo prebuild (Android)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
+        working-directory: example-expo
+        run: yarn expo prebuild --platform android
+
+      - name: Cache Gradle (Expo)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/wrapper
+            ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-expo-${{ hashFiles('example-expo/android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-expo-
+
+      - name: Build example-expo for Android
+        if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
+        working-directory: example-expo/android
+        run: ./gradlew assembleDebug
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,10 @@ jobs:
         run: |
           /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
 
+      - name: Build config plugin
+        if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
+        run: yarn build:plugin
+
       - name: Expo prebuild (Android)
         if: github.event_name != 'pull_request' || steps.changes.outputs.relevant == 'true'
         working-directory: example-expo

--- a/docs/device-verification-runbook.md
+++ b/docs/device-verification-runbook.md
@@ -1,0 +1,121 @@
+# Device Verification Runbook — usePrefetch + PrefetchWindow cancellation
+
+Covers [[usecases/UC-DeviceVerifiedPrefetchCancellation]]. Verifies, on real hardware, that
+the sliding-window prefetch driven by `usePrefetch` actually moves segments to disk, evicts
+them as the window slides, and that shrinking the window (which is what cancels an in-flight
+prefetch — see "API note" below) stops the underlying native transfer, not just the JS
+`'cancelled'` state.
+
+Target screen: `example/`'s `VideoList` screen (`example/src/components/VideoList.tsx`), which
+wires `usePrefetch` onto the existing video `FlatList` via `onViewableItemsChanged` /
+`viewabilityConfig` (TASK-014). No new screen is built for this runbook.
+
+> **API note (assumption, recorded per task-executor zero-guessing rule):** the task title
+> refers to "`PrefetchWindow.cancel()`". Reading `src/Provider/PrefetchWindow.ts` shows
+> `cancel()`/`dispose()` only clear the internal busy-poll timer — they do not cancel
+> individual in-flight segment downloads. The mechanism that actually stops an in-flight
+> native transfer is `setActiveWindow()` dropping a URL out of the window (steps 358-368: each
+> item that leaves the window gets its own `sessionTask.cancelTask(url)`), which is exactly
+> what happens when the user scrolls the window past that item. This runbook exercises that
+> real cancellation path (Step 4) rather than the literal `cancel()` method, since that is
+> the only one with a device-observable native-transfer effect.
+
+## Prerequisites
+
+- `example/` app buildable and installable on the target device (`yarn && cd ios && pod
+  install` for iOS; standard `react-native run-android` toolchain for Android).
+- Device has internet access to the source URLs in `example/src/data/streams.ts`.
+- A way to inspect the app's cache directory on-device:
+  - iOS: Xcode → Devices and Simulators → select device → "Download Container…" on the
+    installed app, then inspect the extracted `.xcappdata` (or use `idevicefs`/a jailed file
+    browser if available). Cache files live under the app's `Library/Caches` (or the path
+    `FileSystemManager`/`tempCachePathFor` in `src/Libs/fileSystem.ts` resolves to).
+  - Android: `adb shell run-as <applicationId> ls -la
+    /data/data/<applicationId>/cache/<bucket>` (bucket per `FileBucket` in
+    `src/Libs/fileSystem.ts`), or `adb shell run-as <applicationId> du -sh
+    /data/data/<applicationId>/cache`.
+- A way to observe in-flight network activity stopping: OS-level connection list
+  (iOS: Instruments/Network Link Conditioner + Console log lines from the native module if any;
+  Android: `adb shell cat /proc/net/tcp` diffed before/after, or Android Studio Network
+  Profiler attached to the running process).
+
+## Steps
+
+1. **Launch.** Build and install `example/` on the physical device (`npx react-native
+   run-ios --device` / `run-android`, or open in Xcode/Android Studio and run on the
+   connected device). Open the app; it lands on the `VideoList` screen with the video
+   `FlatList` full-screen and paging.
+
+2. **Advance the window / observe prefetch.** Snapshot the app's cache directory (per
+   Prerequisites) — expect it empty or near-empty. Scroll (page) forward through 3-4 items.
+   After each page settles, re-list the cache directory: expect new segment files to appear
+   for URLs now inside the prefetch window (ahead of the current index), corresponding to
+   `usePrefetch`'s `onViewableItemsChanged` → `setActiveWindow` call.
+
+3. **Observe eviction.** Continue scrolling forward several more pages so earlier items fall
+   out of the window. Re-list the cache directory: expect the segment files for URLs that
+   are now outside the window (behind, beyond the window's rear edge) to be gone — evicted as
+   `setActiveWindow`'s distance-sorted diff drops them, not merely accumulating forever.
+
+4. **Trigger cancellation of an in-flight prefetch.** Pick a moment where a segment
+   currently mid-download (visible as a partial/temp file in the cache dir, or via the
+   network observation tool) is about to leave the window. Scroll past it in one motion so
+   it exits the window before the download would naturally finish. Confirm two things
+   independently:
+   - **JS state**: (optional, dev-build only) if a debug log/dev menu exposes prefetch item
+     state, confirm it flips to `'cancelled'`.
+   - **Native transfer**: re-check the OS-level network observation tool — the connection for
+     that URL is actually torn down (no further bytes transferred), and re-list the cache
+     directory — no completed file appears for that URL after the cancellation point, only
+     (at most) a stale temp/partial file that verified-write's temp→verify→promote flow never
+     promoted. This is the AC's "confirms the underlying native transfer stops, not just the
+     JS `'cancelled'` state flip".
+
+## Results
+
+| Field | iOS | Android |
+|---|---|---|
+| Device model | _pending_ | _pending_ |
+| OS version | _pending_ | _pending_ |
+| Step 2 (prefetch on scroll) | _pending_ | _pending_ |
+| Step 3 (eviction on scroll) | _pending_ | _pending_ |
+| Step 4 (cancellation stops native transfer) | _pending_ | _pending_ |
+| Overall | **pending** — no physical device was reachable from the execution environment this runbook was authored in (see Execution Log) | **pending** — no physical device was reachable from the execution environment this runbook was authored in (see Execution Log) |
+
+## Execution Log
+
+- **2026-08-21, task-executor (TASK-009, r1-a1):** attempted to execute this runbook against a
+  physical device pair as required by AC-3/AC-4. Device discovery in the execution environment:
+  - `xcrun xctrace list devices` → one physical iPhone listed, but under "Devices **Offline**"
+    (`Liberty's iPhone (18.6.2)`, not connected/reachable) — no online physical iOS device
+    available to install/run on.
+  - `adb devices` → empty device list — no physical Android device connected.
+  - No physical device was reachable from this environment, so Steps 1-4 could not be
+    performed and no pass/fail result can be honestly recorded for either platform. This is
+    reported as a **fail** on AC-3 and AC-4 (task-executor's own envelope), not silently
+    marked pass — per the task-executor rule that a check with no evidence is not "done".
+  - Filed as a discovery for the run/PO: physical-device execution of this runbook needs to
+    happen in an environment with device access (a developer machine with the devices
+    physically connected/paired, or a device farm) before AC-3/AC-4 can close.
+- **2026-08-21, task-executor (TASK-009, r2-a1):** re-checked device availability in this
+  execution environment; unchanged from r1-a1:
+  - `xcrun xctrace list devices` → same physical iPhone still listed only under "Devices
+    **Offline**" (`Liberty's iPhone (18.6.2)`) — not reachable to build/install/run on.
+  - `adb devices` → still an empty device list — no physical Android device connected.
+  - No new physical device became reachable. Steps 1-4 still could not be performed; AC-3 and
+    AC-4 remain **fail** (no evidence to record), not silently marked pass. The blocker is
+    unchanged from r1-a1 and is not something a code/doc change in this scope's substrate can
+    resolve — it needs execution-environment device access, which is outside this task's
+    substrate (`docs/device-verification-runbook.md`, `.shapeup/hardening-expo-parity/spikes/**`).
+- **2026-08-21, task-executor (TASK-009, r3-a1):** re-checked device availability in this
+  execution environment per the round-3 fix instruction ("execute the runbook on real
+  hardware, or re-scope/waive R4/R5 at the Betting Table"); unchanged from r1-a1/r2-a1:
+  - `xcrun xctrace list devices` — same physical iPhone still listed only under "Devices
+    Offline" (`Liberty's iPhone (18.6.2)`), not reachable to build/install/run on.
+  - `adb devices` — still an empty device list, no physical Android device connected.
+  - No new physical device became reachable. Steps 1-4 still could not be performed; AC-3 and
+    AC-4 remain **fail** (no evidence to record). This scope's substrate is limited to this
+    runbook document and cannot grant itself execution-environment device access or waive its
+    own acceptance criteria. Closing AC-3/AC-4 needs either a developer machine or device farm
+    with physical device access, or a Betting Table decision to re-scope/waive R4/R5 — escalated
+    here rather than re-attempting the same environment check a fourth time.

--- a/shapeup/hardening-expo-parity/REPORT.md
+++ b/shapeup/hardening-expo-parity/REPORT.md
@@ -1,0 +1,97 @@
+---
+type: ship-report
+feature: hardening-expo-parity
+date: 2026-08-21
+verdict: FAIL (full board) — GATE H cut list accepted, 5/6 scopes shipped
+rounds_used: 3
+qa: skipped
+intake_sha256: 5aff356dcfbd175b2f64257351adab7d6f1e30a21d9a7b5e10899d84d3e7f12d
+---
+
+# hardening-expo-parity — ship report
+
+Frozen at GATE L4. Every figure below is derived from run artifacts on disk — the trial
+ledger, the verdict artifacts, the board — never from a summary of the run.
+
+## Outcome
+
+| | |
+|---|---|
+| Verdict | **FAIL (full board) — GATE H cut list accepted, 5/6 scopes shipped** |
+| Rounds used | 3 |
+| Board | 9/12 tasks done |
+| T0 artifacts | 9 |
+| QA | skipped |
+
+> **3 task(s) did not finish:** TASK-009, TASK-010, TASK-011.
+> The verdict above grades what was built, not what was planned.
+
+## Leftovers (advisory)
+
+Markers in lines this run ADDED. Not a gate and not part of the verdict — a cleanup list.
+
+- src/ProxyCacheManager.ts: commented-out code block
+- src/types/cacheAsset.d.ts: commented-out code block
+- src/__tests__/content-range.test.ts: +491 lines in one file
+
+## Verification (T0)
+
+The surviving trial per scope — the one describing code that is actually on the branch.
+
+| scope | fixtures | regressions | trials | last status | delta |
+|---|---|---|---|---|---|
+| cache-key-policy-configuration | 2/2 | 0 | 3 | kept | no change |
+| cache-status-event-export | 2/2 | 0 | 2 | kept | +1 fixture |
+| device-verified-prefetch-cancellation | 1/1 | 0 | 1 | kept | baseline |
+| expo-ci-build-signal | 1/1 | 0 | 2 | kept | no change |
+| ranged-cache-hit-content-range | 3/3 | 0 | 1 | kept | baseline |
+
+## Ratchet
+
+Measured over this run's trial ledger. A monotone series is a ratchet working; a flat or
+sawtooth series says the loop is still a budgeted retry loop wearing a ratchet's shape.
+
+| | |
+|---|---|
+| Trials | 9 across 5 scope(s), 3 with more than one attempt |
+| Improvement rate | 1 — kept ÷ trials after the first |
+| Monotone rate | 1 — multi-trial scopes whose score never decreased |
+| Sawtooth count | 0 — a revert immediately after a keep |
+| Mean trials to green | 1.2 |
+| Statuses | kept 9 |
+
+## Evaluation
+
+| Criterion | Dimension | Verdict | Confidence | Reprobed | Evidence |
+|---|---|---|---|---|---|
+| `expo-videolist-parity` scope has a T0 verdict for round 3 | spec-conformance | FAIL | high | yes | No file under `.shapeup/hardening-expo-parity/t0/verdicts/` with `scope_id: expo-videolist-parity`; `t0/trials.jsonl` has no entry for this scope in any round; no order/result artifact anywhere for this scope |
+| UC-CacheKeyPolicyConfiguration steps | spec-conformance | PASS | high | n/a | T0 `r3-a1-t1.json` green (2/2 fixtures, 0 regressions, no change vs r2); `src/Utils/cacheKeyPolicy.ts` implements `denylistParams`/`urlKeyExtractor` per INV-03 (extractor fully overrides default derivation); full suite green |
+| UC-CacheStatusEventExport — `RNCV_CACHE_STATUS` importable from package entry | spec-conformance | PASS | high | n/a | T0 `r1-a2-t1.json` green (2/2, unchanged); `src/index.tsx:5` `CACHE_STATUS_EVENT as RNCV_CACHE_STATUS` re-exported from the package entry barrel |
+| UC-RangedCacheHitContentRange INV-01..05 | spec-conformance | PASS | high | yes | T0 `r3-a1-t2.json` green (3/3 fixtures, 0 regressions, baseline trial) — scope now T0-attested, resolving round 2's structural gap; `src/types/cacheAsset.d.ts:28,48` (`totalLength?`, `SegmentTotalLengthRecord` side-map); `src/ProxyCacheManager.ts:1175-1176` (`sendRaw(206, ..., {'Content-Range': ...})`); `npx jest src/__tests__/content-range.test.ts` passing; full repo suite `npx jest` → 24 suites / 314 tests, 0 failures |
+| UC-ExpoVideoListParity — mirror VideoList/VideoItem/streams.ts, wire App.tsx | spec-conformance | FAIL | high | yes | `example-expo/src/components/` contains only `SingleVideo.tsx` — no `VideoList.tsx`, no `VideoItem.tsx`. `example-expo/src/data/` does not exist. `example-expo/src/App.tsx:4` imports only `./components/SingleVideo`; no `VideoList` reference in the file. `git status --short` shows zero changes under `example-expo/` this round. `TASK-010`/`TASK-011` both still `status: ready`. Re-probed via a second `find`/`grep` pass — same result, stable across 3 rounds |
+| UC-DeviceVerifiedPrefetchCancellation INV-01 — pass/fail recorded for BOTH physical devices | spec-conformance | FAIL | high | yes | `docs/device-verification-runbook.md:78-79` — `Device model \| _pending_ \| _pending_`, `OS version \| _pending_ \| _pending_`; lines 94-96 state in the document's own words: "no pass/fail result can be honestly recorded for either platform... reported as a **fail** on AC-3 and AC-4"; task frontmatter now `status: in-progress` (was `ready` in r2), but the runbook body is unchanged from round 2 |
+| UC-ExpoCIBuildSignal INV-01 (distinct cache key) | spec-conformance | PASS | high | n/a | T0 `r2-a1-t2.json` green, unchanged; `.github/workflows/ci.yml:159` key `${{ runner.os }}-gradle-expo-...`, distinct from `build-android`'s `-gradle-` key |
+| UC-ExpoCIBuildSignal INV-02 (triggers on `example-expo/**` alone) | spec-conformance | PASS | high | n/a | `.github/workflows/ci.yml:115-120` `dorny/paths-filter` filters on `src/**` and `example-expo/**` |
+| UC-ExpoCIBuildSignal precondition — "UC-ExpoVideoListParity has landed... validates the fuller app" | spec-conformance | FAIL | high | yes | UC's own Preconditions state the job is meaningless without the VideoList demo's files present. Since UC-ExpoVideoListParity remains unimplemented (above), `build-android-expo` (`.github/workflows/ci.yml:104-165`) still builds only the pre-existing `SingleVideo` app — mechanically green, but not exercising the surface this UC's Summary promises |
+
+### Refuted criteria and bugs
+
+| Severity | Criterion | Location | Repro | Expected | Actual |
+|---|---|---|---|---|---|
+| Critical | `expo-videolist-parity` (R6) — never dispatched | `example-expo/src/components/`, `example-expo/src/App.tsx`, `.shapeup/hardening-expo-parity/tasks/TASK-010*.md`, `TASK-011*.md` | `ls example-expo/src/components/`; `grep status .shapeup/hardening-expo-parity/tasks/TASK-01{0,1}*.md` | `VideoList.tsx`, `VideoItem.tsx` present; `App.tsx` wires `VideoList`; tasks `status: done` | Only `SingleVideo.tsx` present; `example-expo/src/data/` missing entirely; both tasks still `status: ready` after 3 rounds — no result/order artifact for this scope exists anywhere |
+| High | UC-DeviceVerifiedPrefetchCancellation (R4/R5) | `docs/device-verification-runbook.md:78-79` | Open the runbook, read the Device Model/OS Version row | A pass/fail result recorded for one physical iOS device and one physical Android device | Both columns `_pending_`; document self-reports "fail" on AC-3/AC-4 for lack of device access; task frontmatter moved to `in-progress` this round but runbook body unchanged |
+| Medium | UC-ExpoCIBuildSignal (R7) sequencing | `.github/workflows/ci.yml:104-165` | Inspect what `build-android-expo` currently builds | The job validates the VideoList/`usePrefetch` demo per its own Summary | Job is mechanically correct but currently builds only the pre-existing `SingleVideo` screen, because R6 has not landed |
+
+## Discovered, not built
+
+~ [ORIENT] A3's stated shape ("one new optional field on the owning registry entry") is confirmed correct for CacheEntry.kind === 'media' but architecturally wrong for kind === 'hls': one HLS owner entry (keyed by the playlist's key, src/ProxyCacheManager.ts:847-862) is shared across every segment in segmentPaths: string[] (src/types/cacheAsset.d.ts:23-28), and different segments have different total lengths — a single scalar field on the owner cannot hold a correct per-segment value.
++ [ORIENT] Two additive alternatives identified for A3's HLS case that avoid a REGISTRY_VERSION bump: (1) widen segmentPaths to Array<{path,totalLength?}> (needs a one-time normalize-on-load since persisted JSON gives back bare strings), or (2) a separate per-file side map keyed by the range-suffixed absFilePath, persisted as its own top-level registry section, leaving CacheEntry untouched — the lower-blast-radius option.
++ [ORIENT] addSegmentHandler's disk-hit branch (src/ProxyCacheManager.ts:1075) does no registry lookup at all today — it reads straight from absoluteFilePath(filePath, headers) via readStream; confirmed addSegmentHandler is the single handler for every non-playlist proxied URL (HLS segment or plain MP4), via addRequestHandlers (src/ProxyCacheManager.ts:819).
++ [ORIENT] A2's fallback seam confirmed precisely: cacheKeyPolicy.ts:63 (policy?.denylistParams ?? DEFAULT_DENYLIST_PARAMS) and cacheKeyPolicy.ts:94 (policy?.urlKeyExtractor) already read an optional policy param — a module-level getDefaultCacheKeyPolicy() needs zero call-site edits at any of the ~15 sites, confirming the pitch's RH1-avoidance claim rather than assuming it.
+~ [ORIENT] A3's eviction interaction is untraced: didEvictHandler (src/ProxyCacheManager.ts:498) only ever receives the owner CacheEntry for an HLS asset, never individual segment paths, so neither additive shape for the HLS case has an existing hook to garbage-collect stale per-segment total-length data on eviction — worth a build-time read before A3's shape locks.
+
+---
+
+*Run state (board, orders, results, T0 artifacts, evaluation and QA reports) stays in the
+gitignored local tier (ADR-0001). This report
+is the frozen conclusion of it.*

--- a/shapeup/hardening-expo-parity/hill/cache-key-policy-configuration.yml
+++ b/shapeup/hardening-expo-parity/hill/cache-key-policy-configuration.yml
@@ -1,0 +1,2 @@
+scope_id: cache-key-policy-configuration
+phase: DOWNHILL_EXECUTION

--- a/shapeup/hardening-expo-parity/hill/cache-status-event-export.yml
+++ b/shapeup/hardening-expo-parity/hill/cache-status-event-export.yml
@@ -1,0 +1,2 @@
+scope_id: cache-status-event-export
+phase: DOWNHILL_EXECUTION

--- a/shapeup/hardening-expo-parity/hill/device-verified-prefetch-cancellation.yml
+++ b/shapeup/hardening-expo-parity/hill/device-verified-prefetch-cancellation.yml
@@ -1,0 +1,2 @@
+scope_id: device-verified-prefetch-cancellation
+phase: DOWNHILL_EXECUTION

--- a/shapeup/hardening-expo-parity/hill/expo-ci-build-signal.yml
+++ b/shapeup/hardening-expo-parity/hill/expo-ci-build-signal.yml
@@ -1,0 +1,2 @@
+scope_id: expo-ci-build-signal
+phase: DOWNHILL_EXECUTION

--- a/shapeup/hardening-expo-parity/hill/expo-videolist-parity.yml
+++ b/shapeup/hardening-expo-parity/hill/expo-videolist-parity.yml
@@ -1,0 +1,2 @@
+scope_id: expo-videolist-parity
+phase: UPHILL_SOLVED

--- a/shapeup/hardening-expo-parity/hill/ranged-cache-hit-content-range.yml
+++ b/shapeup/hardening-expo-parity/hill/ranged-cache-hit-content-range.yml
@@ -1,0 +1,2 @@
+scope_id: ranged-cache-hit-content-range
+phase: DOWNHILL_EXECUTION

--- a/shapeup/hardening-expo-parity/project-profile.md
+++ b/shapeup/hardening-expo-parity/project-profile.md
@@ -1,0 +1,17 @@
+---
+schema_version: 1
+archetype: library
+entry_point: src/index.tsx
+---
+
+# Project Profile — hardening-expo-parity
+
+`react-native-cache-video` is a React Native library (TurboModule-backed HLS/MP4 caching proxy),
+not an app or service. The reachability seam for every use case in this pitch is the package's
+own public export surface, `src/index.tsx` — a use case is "wired in" when it is reachable from
+that entry point (a new named export, a behavior change behind an existing exported function, or
+a change to `example/` / `example-expo/` as a first-party consumer of that same entry point).
+
+Consumers: `example/` (bare RN) and `example-expo/` (Expo dev-client + prebuild) both import
+exclusively from `src/index.tsx` (via the package name in their own `node_modules` symlink /
+workspace link) — neither app reaches into `src/` internals directly.

--- a/shapeup/hardening-expo-parity/scope-board.md
+++ b/shapeup/hardening-expo-parity/scope-board.md
@@ -1,0 +1,25 @@
+---
+type: scope-board
+feature: hardening-expo-parity
+---
+
+# Scope Board: 0.5.1 Hardening + Expo Parity
+
+| scope_id | topology | use_cases | depends_on | files | lint |
+|---|---|---|---|---|---|
+| cache-key-policy-configuration | ICEBERG | UC-CacheKeyPolicyConfiguration | — | src/Utils/cacheKeyPolicy.ts, src/Utils/index.ts, src/__tests__/cache-key-policy.test.ts | pending |
+| cache-status-event-export | CHOWDER | UC-CacheStatusEventExport | — | src/index.tsx | pending |
+| ranged-cache-hit-content-range | ICEBERG | UC-RangedCacheHitContentRange | — | src/types/cacheAsset.d.ts, src/ProxyCacheManager.ts, src/__tests__/registry-eviction.test.ts, src/__tests__/hls-ingest.test.ts, src/__tests__/hls-ingest-prefetch-forwarder.test.ts, src/__tests__/http-proxy.test.ts, src/__tests__/verified-cache-writes.test.ts, src/__tests__/full-lifecycle.test.ts, src/__tests__/content-range.test.ts | pending |
+| device-verified-prefetch-cancellation | CHOWDER | UC-DeviceVerifiedPrefetchCancellation | — | docs/device-verification-runbook.md | pending |
+| expo-videolist-parity | LAYER_CAKE | UC-ExpoVideoListParity | — | example-expo/src/components/VideoList.tsx, example-expo/src/components/VideoItem.tsx, example-expo/src/data/streams.ts, example-expo/App.tsx | pending |
+| expo-ci-build-signal | CHOWDER | UC-ExpoCIBuildSignal | expo-videolist-parity | .github/workflows/ci.yml | pending |
+
+## Build order (Kahn levels of `depends_on`)
+
+- Wave 1 (no dependencies): cache-key-policy-configuration, cache-status-event-export,
+  ranged-cache-hit-content-range, device-verified-prefetch-cancellation, expo-videolist-parity
+- Wave 2: expo-ci-build-signal (needs expo-videolist-parity)
+
+Riskiest-first within available waves: `ranged-cache-hit-content-range` (tagged `highest-risk`
+by the pitch's own spike — the corrected side-map shape for HLS segment totals) should dispatch
+first among the wave-1 scopes.

--- a/shapeup/hardening-expo-parity/scopes/cache-key-policy-configuration.md
+++ b/shapeup/hardening-expo-parity/scopes/cache-key-policy-configuration.md
@@ -1,0 +1,36 @@
+---
+scope_id: cache-key-policy-configuration
+topology_type: ICEBERG
+use_cases: [UC-CacheKeyPolicyConfiguration]
+depends_on: []
+allowed_file_substrate:
+  - src/Utils/cacheKeyPolicy.ts
+  - src/Utils/index.ts
+  - src/__tests__/cache-key-policy.test.ts
+shared_substrate: []
+affordance_manifest: []
+e2e_verification_fixtures:
+  - "yarn typecheck"
+  - "yarn test src/__tests__/cache-key-policy.test.ts"
+hill_phase: UPHILL_UNKNOWN
+---
+
+## Why this slice
+
+One flow, start to finish: a module-level default-policy store and the `normalizeCacheKey`
+fallback-order rewrite live in `src/Utils/cacheKeyPolicy.ts`; the package's own `Utils` barrel
+(`src/Utils/index.ts`) re-exports the new symbols so `src/index.tsx`'s existing
+`export * from './Utils'` wildcard carries them to the package root with no second export block;
+`src/__tests__/cache-key-policy.test.ts` (already on disk) proves the fallback reaches ≥2 of the
+~15 existing call sites (`ProxyCacheManager`, `PrefetchWindow`) with zero edits to those call
+sites, and that prefetch-time and playback-time keys still agree for the same URL under a
+configured default (RH1). Implementation/store complexity outweighs the test file — ICEBERG, not
+LAYER_CAKE.
+
+This scope never edits `ProxyCacheManager.ts`, `PrefetchWindow.ts`, or `src/index.tsx` — only
+its own barrel. `CacheStatus`/`CACHE_STATUS_EVENT`'s export lives in a separate use case
+(`cache-status-event-export`, different symbols, different file family) and is not this scope's
+concern even though both land inside "the export surface" loosely speaking: the two use cases
+have no shared flow — one widens `src/Utils/index.ts`, the other widens `src/index.tsx` directly
+— so each gets its own scope rather than one shared "export" scope that would leave two use
+cases racing to claim the same contract.

--- a/shapeup/hardening-expo-parity/scopes/cache-status-event-export.md
+++ b/shapeup/hardening-expo-parity/scopes/cache-status-event-export.md
@@ -1,0 +1,31 @@
+---
+scope_id: cache-status-event-export
+topology_type: CHOWDER
+use_cases: [UC-CacheStatusEventExport]
+depends_on: []
+allowed_file_substrate:
+  - src/index.tsx
+shared_substrate: []
+affordance_manifest: []
+e2e_verification_fixtures:
+  - "yarn typecheck"
+  - "yarn test"
+hill_phase: UPHILL_UNKNOWN
+---
+
+## Why this slice
+
+`CACHE_STATUS_EVENT`/`CacheStatus` are already declared inside `src/ProxyCacheManager.ts`
+(read-only from here — no edit) with an existing named re-export block for that same file already
+living in `src/index.tsx`; this use case's entire deliverable is widening that one existing block
+by two names (`CACHE_STATUS_EVENT as RNCV_CACHE_STATUS`, `type CacheStatus`). There is no second
+directory or layer to cross — a true single-file stray, not a directory grab — so this is the
+declared CHOWDER exception rather than a forced two-layer LAYER_CAKE/ICEBERG label. It shares no
+flow with `cache-key-policy-configuration`: that scope widens `src/Utils/index.ts`'s barrel, this
+one widens `src/index.tsx` directly for an unrelated symbol family (a cache lifecycle event, not
+a key-derivation policy), so they cannot be folded into one "export surface" scope without two
+use cases racing to claim the same contract.
+
+`yarn test` (full suite) is this use case's own stated AC ("no existing `emitCacheStatus` call
+site behavior changes") — no new test file is required by the spec, only that nothing already
+passing regresses.

--- a/shapeup/hardening-expo-parity/scopes/device-verified-prefetch-cancellation.md
+++ b/shapeup/hardening-expo-parity/scopes/device-verified-prefetch-cancellation.md
@@ -1,0 +1,29 @@
+---
+scope_id: device-verified-prefetch-cancellation
+topology_type: CHOWDER
+use_cases: [UC-DeviceVerifiedPrefetchCancellation]
+depends_on: []
+allowed_file_substrate:
+  - docs/device-verification-runbook.md
+shared_substrate: []
+affordance_manifest: []
+e2e_verification_fixtures:
+  - "bash -c 'test -f docs/device-verification-runbook.md && grep -q \"iOS\" docs/device-verification-runbook.md && grep -q \"Android\" docs/device-verification-runbook.md && grep -qi \"pass\\|fail\" docs/device-verification-runbook.md'"
+hill_phase: UPHILL_UNKNOWN
+---
+
+## Why this slice
+
+This use case's entire deliverable is one artifact: a repeatable runbook targeting the existing,
+unmodified bare-RN example app's `VideoListPrefetch` screen, executed once on a physical iOS
+device and once on a physical Android device, with pass/fail recorded in the document itself.
+There is no source-code call chain to slice — the "flow" is the runbook's own numbered steps plus
+its results section — and no other scope touches `docs/`, so this is the declared CHOWDER
+exception (a true single-file stray) rather than a forced two-layer label.
+
+The fixture is mechanical, not a device stand-in: it asserts the runbook exists and its results
+section actually records both platforms with a pass/fail outcome, which is the one thing T0 can
+check without physical hardware. It cannot verify the runbook's steps were followed correctly —
+that judgment belongs to EVAL, reading the recorded results — only that the deliverable's
+required shape is present. Automated verification of "the native transfer actually stopped" is
+out of this scope's reach by design.

--- a/shapeup/hardening-expo-parity/scopes/expo-ci-build-signal.md
+++ b/shapeup/hardening-expo-parity/scopes/expo-ci-build-signal.md
@@ -1,0 +1,30 @@
+---
+scope_id: expo-ci-build-signal
+topology_type: CHOWDER
+use_cases: [UC-ExpoCIBuildSignal]
+depends_on: [expo-videolist-parity]
+allowed_file_substrate:
+  - .github/workflows/ci.yml
+shared_substrate: []
+affordance_manifest: []
+e2e_verification_fixtures:
+  - "bash -c 'grep -q \"build-android-expo\" .github/workflows/ci.yml && grep -q \"example-expo\" .github/workflows/ci.yml'"
+hill_phase: UPHILL_UNKNOWN
+---
+
+## Why this slice
+
+One flow: a new `build-android-expo` CI job mirroring the existing `build-android` job's steps
+(prebuild → Gradle assemble) but scoped to the Expo example app, triggered on PRs touching
+`src/**` or the Expo app's own tree, with its own distinct Gradle/turbo cache key. Single file
+(`.github/workflows/ci.yml`), no other scope touches it — the existing bare-RN `build-android`
+job is read-only reference here, never edited. There is no second directory to cross, so this is
+the declared CHOWDER exception rather than a forced two-layer label. `depends_on:
+[expo-videolist-parity]` mirrors the spec's own use-case edge in `spec/usecases/_index.md` ("CI
+validates the demo, so it lands second within W1") — the job it adds builds the very Expo example
+app `expo-videolist-parity` populates, so it must land after.
+
+The fixture is a static shape-check on the workflow file (job name + path trigger present) — it
+cannot itself run a GitHub Actions job locally; the use case's own acceptance criteria call for a
+test PR (or a documented dry run) as the actual trigger verification, which is an EVAL/QA-time
+check against the live repo, not a local T0 command.

--- a/shapeup/hardening-expo-parity/scopes/expo-videolist-parity.md
+++ b/shapeup/hardening-expo-parity/scopes/expo-videolist-parity.md
@@ -1,0 +1,34 @@
+---
+scope_id: expo-videolist-parity
+topology_type: LAYER_CAKE
+use_cases: [UC-ExpoVideoListParity]
+depends_on: []
+allowed_file_substrate:
+  - example-expo/src/components/VideoList.tsx
+  - example-expo/src/components/VideoItem.tsx
+  - example-expo/src/data/streams.ts
+  - example-expo/App.tsx
+shared_substrate: []
+affordance_manifest:
+  - test_id: ExpoVideoListPrefetch.VideoList
+    role: swap-in list component (mirrors the bare-RN example's VideoList exactly; not default-mounted)
+    required_states: [idle, warming, warmed, evicted]
+e2e_verification_fixtures:
+  - "yarn workspace react-native-cache-video-example-expo typecheck"
+hill_phase: UPHILL_UNKNOWN
+---
+
+## Why this slice
+
+One flow: mirror the bare-RN example app's `VideoList`/`VideoItem`/`streams.ts` byte-for-byte
+into the Expo example app's `src/` (only creating what's missing), then wire the Expo app's
+`App.tsx` to make `VideoList` reachable as a swappable component — `SingleVideo` stays the
+default mount, per the pitch's resolved open question OQ5. UI screen (`App.tsx`) and its
+component tree (`VideoList`/`VideoItem`/`streams.ts`) are one balanced flow inside one app
+package — LAYER_CAKE. The bare-RN example's own files are explicitly out of substrate and are
+never written here, only read as the mirror source.
+
+The affordance manifest's state names (`idle`/`warming`/`warmed`/`evicted`) are taken verbatim
+from `spec/ux-behavior.md`'s own `ExpoVideoListPrefetch` state table rather than the generic
+five-state set — this is a library archetype (per `project-profile.md`), and the UX spec already
+declares this screen's actual states identical to the bare-RN `VideoList`'s.

--- a/shapeup/hardening-expo-parity/scopes/ranged-cache-hit-content-range.md
+++ b/shapeup/hardening-expo-parity/scopes/ranged-cache-hit-content-range.md
@@ -1,0 +1,47 @@
+---
+scope_id: ranged-cache-hit-content-range
+topology_type: ICEBERG
+use_cases: [UC-RangedCacheHitContentRange]
+depends_on: []
+allowed_file_substrate:
+  - src/types/cacheAsset.d.ts
+  - src/ProxyCacheManager.ts
+  - src/__tests__/registry-eviction.test.ts
+  - src/__tests__/hls-ingest.test.ts
+  - src/__tests__/hls-ingest-prefetch-forwarder.test.ts
+  - src/__tests__/http-proxy.test.ts
+  - src/__tests__/verified-cache-writes.test.ts
+  - src/__tests__/full-lifecycle.test.ts
+  - src/__tests__/content-range.test.ts
+shared_substrate: []
+affordance_manifest: []
+e2e_verification_fixtures:
+  - "yarn typecheck"
+  - "yarn test src/__tests__/content-range.test.ts"
+  - "yarn test src/__tests__/registry-eviction.test.ts"
+hill_phase: UPHILL_UNKNOWN
+---
+
+## Why this slice
+
+One call chain, tagged `highest-risk` by the pitch's own spike: persist a total length on
+origin MISS (`kind: media` on `CacheEntry` itself, `kind: hls` on the separate
+`SegmentTotalLengthRecord` side map — deliberately NOT the same field, per the domain model
+correction), tie the side map into `didEvictHandler`'s eviction GC, then wire the disk-hit
+branch of `addSegmentHandler` to answer `206`/`Content-Range` when a total is on record and fall
+back to today's unconditional `200` otherwise (R3). This use case's steps all write inside
+`src/ProxyCacheManager.ts` and `src/types/cacheAsset.d.ts` — splitting the persistence, side-map,
+eviction tie-in, and hit-branch wiring into separate scopes would race the same file for no
+benefit. Complexity is concentrated on the implementation/registry side (persistence, side-map,
+eviction tie-in, Range-header parsing reuse) against a comparatively thin round-trip test —
+ICEBERG.
+
+`src/__tests__/content-range.test.ts` does not exist yet; the use case's own test-surface calls
+for "a new full round-trip suite" without fixing a filename, so this name is this scope's own
+choice, not a spec fact — the substrate reserves it. The five existing test files listed are
+where the "registry/write-path", "registry/eviction", and "proxy/segment-handler" suites this use
+case cites already live; only files actually touched should be edited. This scope never edits
+`src/Utils/cacheKeyPolicy.ts`, `src/Utils/index.ts`, or `src/index.tsx` — the
+`CACHE_STATUS_EVENT`/`CacheStatus` declarations it sits next to in `ProxyCacheManager.ts`
+(lines 155-156) are read-only from here; their export lives in the separate
+`cache-status-event-export` scope.

--- a/shapeup/hardening-expo-parity/shaping/breadboard.md
+++ b/shapeup/hardening-expo-parity/shaping/breadboard.md
@@ -1,0 +1,123 @@
+---
+shaping: true
+feature: "[[hardening-expo-parity]]"
+status: breadboarded
+---
+
+# 0.5.1 hardening + Expo parity — Breadboard
+
+Domain adaptation (per AGENTS.md): this is a library, not a screen flow. A **Place** is a
+discrete point in the library's public API / native bridge surface / cache lifecycle. An
+**affordance** is a JS export, native method, or cache-state transition a caller can invoke or
+observe. **U** affordances are used only where a real screen exists (`example-expo/`'s demo UI);
+everything else in the library/CI surface is **N** (code/mechanism), matching breadboarding.md's
+"Backend is a Place" convention.
+
+Mapping to the shape: A1→P1, A2→P2, A3→P3+P4, A4→P5+P6, A5→P7, A6→P8.
+
+## Places
+
+| # | Place | Description |
+|---|---|---|
+| P1 | Package Entry Point | `src/index.tsx` — the public JS export surface a host app imports from |
+| P2 | Cache-Key Policy Module | `src/Utils/cacheKeyPolicy.ts` — key/path derivation, existing + new default-policy store |
+| P3 | Native HTTP Proxy Request Cycle | `ProxyCacheManager`'s `addSegmentHandler` — one GET → `respond` round trip |
+| P4 | Cache Registry | `_memoryCache` (`MemoryCacheProvider`) — persisted, versioned `CacheEntry` store |
+| P5 | usePrefetch / PrefetchWindow | Sliding-window prefetch lifecycle, JS-side |
+| P6 | Native Transfer (react-native-blob-util) | The actual native download session `.cancel()` must stop |
+| P7 | example-expo App (Expo Dev Client) | The running demo screen a developer opens |
+| P8 | CI Pipeline | GitHub Actions (`.github/workflows/ci.yml`) |
+
+## Code Affordances Table
+
+| # | Place | Component | Affordance | Control | Wires Out | Returns To |
+|---|---|---|---|---|---|---|
+| N1 | P1 | `src/index.tsx` (NEW) | `export { keyFor, filePathFor, normalizeCacheKey, CacheKeyPolicyOptions, DEFAULT_DENYLIST_PARAMS, setDefaultCacheKeyPolicy, getDefaultCacheKeyPolicy } from './Utils/cacheKeyPolicy'` | import | → N3 | — |
+| N2 | P1 | `src/index.tsx` (edit existing named-export list) | `export { CACHE_STATUS_EVENT as RNCV_CACHE_STATUS, type CacheStatus } from './ProxyCacheManager'` | import | → N12 (subscribe) | — |
+| N3 | P2 | `cacheKeyPolicy.ts` (NEW) | `setDefaultCacheKeyPolicy(policy)` | call | writes module-level default | — |
+| N4 | P2 | `cacheKeyPolicy.ts` (NEW) | `getDefaultCacheKeyPolicy()` | call | read | → N5 |
+| N5 | P2 | `cacheKeyPolicy.ts` (edit `normalizeCacheKey`) | `normalizeCacheKey(url, policy?)` — falls back to N4 only when `policy` is omitted | call | `policy ?? getDefaultCacheKeyPolicy()` → hash/derive | → N6 |
+| N6 | P2 | `ProxyCacheManager.ts` / `PrefetchWindow.ts` / `PreCacheProvider.ts` / `verifiedWrite.ts` | existing `CacheKeyPolicy.keyFor(url)` / `filePathFor(url,...)` call sites — **unchanged call signature, ~15 sites** | call | → N5 | → P4 (registry put/get), → P3 (file path resolution) |
+| N7 | P3 | `ProxyCacheManager.ts` `addSegmentHandler` | cache-HIT branch (`readStream` → `!streamError`) | request event | → N8 | → N9 |
+| N8 | P3 | `ProxyCacheManager.ts` (NEW helper) | parse the CURRENT request's `Range` header (same regex `absoluteFilePath` already uses) + look up persisted total for this asset from P4 | call | → N9 | — |
+| N9 | P3 | `ProxyCacheManager.ts` (edit `addSegmentHandler` HIT branch) | build response: `206` + `Content-Range: bytes {offset}-{length}/{total}` iff Range present AND total on record; **else exactly today's `sendRaw(200, HLS_VIDEO_TYPE, streamData)`** (R3's fallback — same code path, not a branch) | call | → `HttpProxy.respond` (native) | → player |
+| N10 | P3 | `verifiedWrite.ts` `writeTemp` (existing, unchanged) | origin fetch returns `Content-Range`/`Content-Length`; already captured as `WriteTempResult.contentRange`/`contentLength` | native fetch | → N11 | — |
+| N11 | P3 | `ProxyCacheManager.ts` (NEW, in the MISS/promote branch) | persist total resource length onto the owning registry entry (additive optional field; no `REGISTRY_VERSION` bump) | write | → S1 | — |
+| N12 | P3 | `ProxyCacheManager.ts` `emitCacheStatus` (existing, unchanged) | `DeviceEventEmitter.emit(CACHE_STATUS_EVENT, {key, status})` | call | → N2 subscribers | — |
+| N13 | P5 | `usePrefetch.ts` (existing, unchanged) | `onViewableItemsChanged` → `setActiveWindow(urls, currentIndex)` | scroll event | → N14 | — |
+| N14 | P5 | `PrefetchWindow.ts` `setActiveWindow` (existing, unchanged) | enqueue items entering the window / cancel items leaving it | call | → N15, → N16 | — |
+| N15 | P5 | `PrefetchWindow.ts` (existing, unchanged) | per-item prefetch download (`sessionTask.dataTask`) | call | → P6 | → P4 (`registerPrefetchedPlaylist`/segment) |
+| N16 | P5 | `PrefetchWindow.ts` `cancel()` (existing, unchanged) | per-item `sessionTask.cancelTask(url)` | call | → P6 | — |
+| N17 | P6 | `react-native-blob-util` fetch/downloadTask (existing, native, unchanged) | in-flight native download | native | — | → N15 (settled) |
+| N18 | P6 | `downloadTask.cancel()` (existing, native, unchanged) | native cancel | call | **device-VERIFICATION TARGET (A4)** — does the native transfer actually stop, not just JS state | — |
+| N19 | P5/P6 | `docs/` (NEW) `device-verification-runbook.md` | step-by-step manual script: scroll `example/`'s list on real iOS + Android hardware, trigger prefetch (N13→N17) and cancel (N16→N18), record pass/fail | manual execution | reads N17/N18's real-device behavior | → runbook pass/fail log |
+| N20 | P8 | `.github/workflows/ci.yml` (NEW job) | `expo prebuild` (Android target) inside `example-expo/` | CI run | → N21 | — |
+| N21 | P8 | `.github/workflows/ci.yml` (NEW job) | `cd example-expo/android && ./gradlew assembleDebug --no-daemon` | CI run | — | → PR check (pass/fail) |
+
+## Data Stores Table
+
+| # | Place | Store | Description |
+|---|---|---|---|
+| S1 | P4 | `_memoryCache` (`CacheEntry` map) | Existing registry, **+ one new optional field** (total resource length) written by N11, read by N8 |
+| S2 | P2 | module-level default policy | Existing-shape addition: a single `CacheKeyPolicyOptions \| undefined`, written by N3, read by N4/N5 |
+
+## UI Affordances Table (P7 only — the one real screen in this pitch)
+
+| # | Place | Component | Affordance | Control | Wires Out | Returns To |
+|---|---|---|---|---|---|---|
+| U1 | P7 | `example-expo/src/App.tsx` (existing, unchanged) | mounts `<CacheManagerProvider>` | render | → P2/P3 (library init) | — |
+| U2 | P7 | `example-expo/src/components/VideoList.tsx` (NEW, mirrored from `example/`) | scrolling `FlatList` of videos | scroll | → N13 | ← S3 |
+| U3 | P7 | `example-expo/src/components/VideoList.tsx` (NEW, mirrored) | `onViewableItemsChanged` viewability signal (wired exactly as `example/`'s `VideoList.tsx` already wires it) | scroll | → N13 | — |
+| U4 | P7 | `example-expo/src/components/VideoItem.tsx` (NEW, mirrored if not already present) | per-item video playback view | render | ← P3 (proxied localhost URL) | ← S1 |
+| S3 | P7 | `example-expo/src/data/streams.ts` (NEW, mirrored) | static video list data (same fixture `example/` already uses) | store | → U2 | — |
+
+## Wiring Verification Notes
+
+- **N5/N6 chain preserves default behavior exactly.** Every one of N6's ~15 existing call sites
+  already passes no `policy` argument (verified by reading each call site — see shaping.md
+  Spike Results). `getDefaultCacheKeyPolicy()` returns `undefined` until N3 is ever called, so
+  `policy ?? getDefaultCacheKeyPolicy()` evaluates to `undefined` exactly as `policy` alone did
+  before this change — N6 needs zero edits, confirming A2's "no call-site edits" claim structurally,
+  not just by intent.
+- **N9 is one edit, not a new branch tree.** The hit-branch code today is
+  `sendRaw(200, HLS_VIDEO_TYPE, streamData)` unconditionally. N9 replaces it with a single
+  conditional response-header/status choice; the "total absent" arm of that conditional is
+  byte-identical to the code being replaced, which is what makes R3 (backward-compat fallback)
+  covered by construction rather than by a second code path that could drift out of sync.
+- **N7 has no dependency on N-owner state.** Confirmed by reading `addSegmentHandler`: the hit
+  branch's `sendRaw` call does not gate on `ownerKey`/`owner` the way the MISS branch does — only
+  the *optional* `registerSegmentUnderOwner` bookkeeping call does. So N8/N9 apply uniformly
+  whether the asset is an HLS-owned segment or a plain MP4 that was previously cached.
+- **N11 writes S1, N8 reads S1 — same store, no new persistence layer.** Total length rides in
+  the existing registry export/import path (already disk-persisted, already versioned) rather
+  than a fresh side-store that would need its own lifecycle/eviction handling.
+- **N19 is a Place-external verification step, not a Place of its own with new affordances.** It
+  reads N17/N18's *real* (device) behavior rather than the jest mock's simulated behavior — the
+  runbook's existence and its recorded result are the deliverable for R4/R5, matching the Fit
+  Check.
+- **U2/U3/U4 have a data source.** `S3` (mirrored `streams.ts`) feeds `U2` exactly as `example/`'s
+  own `data/streams.ts` feeds its `VideoList.tsx` today — no invented data shape, same fixture
+  copied verbatim.
+- **N20→N21 mirrors an existing, working job.** `ci.yml`'s current `build-android` job already
+  proves the Gradle-assemble half works in this CI environment; N20 is the only genuinely new
+  mechanism (`expo prebuild` inside CI), and it's exercising a config plugin already shipped and
+  working locally (see shaping.md Spike Results) — not spiking a new integration.
+
+## Slices
+
+Each slice is one demonstrable capability: "watch me do this" against the running library or the
+running example-expo app.
+
+| # | Slice | Mechanism | Demo |
+|---|---|---|---|
+| V1 | Cache-key policy exported and honored | N1, N3, N4, N5 | Call `setDefaultCacheKeyPolicy({ denylistParams: [...] })` before any request; `keyFor()` (also newly exported) returns the same key for two differently-signed URLs of the same resource — proving N6's existing call sites picked it up with no edits |
+| V2 | `RNCV_CACHE_STATUS` exported and usable | N2, N12 | `import { RNCV_CACHE_STATUS } from 'react-native-cache-video'`; `DeviceEventEmitter.addListener(RNCV_CACHE_STATUS, ...)` fires on a real HIT, with no hardcoded event-name string anywhere in the calling code |
+| V3 | Ranged cache-hit returns 206 | N7, N8, N9, N10, N11, S1 | Request the same byte range twice against one HLS segment (or MP4); the second (hit) response carries `206` + a `Content-Range` matching the first (miss) response's total, verified against the running proxy |
+| V4 | Pre-existing cached asset degrades safely | N9 (total-absent arm), S1 | A registry entry seeded with no total-length field still answers a ranged request with `200` — no crash, no synthesized/incorrect `Content-Range` |
+| V5 | Device-verification runbook exists and is executed | N13–N19 | The runbook document walks scrolling `example/`'s list on a real iOS phone and a real Android phone, triggering prefetch and cancel, with a pass/fail recorded per platform at the bottom of the doc |
+| V6 | example-expo shows the VideoList/usePrefetch demo | U1, U2, U3, U4, S3 | Launch `example-expo` on a dev-client build; scroll the list; see the same multi-video, prefetch-driven demo `example/` already shows — not the single-video screen |
+| V7 | example-expo Android build is green in CI | N20, N21 | Open a PR touching `example-expo/` (or the library); the new CI job runs `expo prebuild` + `gradlew assembleDebug` and reports pass/fail as a PR check |
+
+7 slices, all ≤9. V1–V4 are W0 (hardening); V5 closes W0's device-verification items; V6–V7 are
+W1 (Expo parity). Each layers exactly one new mechanism onto what the previous slice proved, and
+none depends on a slice later in the list.

--- a/shapeup/hardening-expo-parity/shaping/shaping.md
+++ b/shapeup/hardening-expo-parity/shaping/shaping.md
@@ -1,0 +1,258 @@
+---
+shaping: true
+feature: "[[hardening-expo-parity]]"
+status: shaped
+appetite: ~1.5-2 weeks
+---
+
+# 0.5.1 hardening + Expo parity — Shaping
+
+## Problem Frame
+
+v0.5.0 shipped and closed the headline caching bugs, but three pieces of its own plan were
+explicitly deferred, and one demo app was left behind. A host app cannot configure which query
+params are stripped from a cache key (or supply its own key-derivation function) even though
+that logic already exists inside the library — there is no public call site, so every install
+gets the same hard-coded denylist. A host app cannot subscribe to cache hit/miss events by name
+either, because the event constant is never exported — only a hard-coded string works. A player
+that seeks into a video whose ranged bytes are already on disk from an earlier request gets back
+`200 OK` instead of `206 Partial Content`, because the total resource length was never persisted
+alongside the cached bytes, so the proxy cannot reconstruct `Content-Range` on replay — some
+players tolerate this, some don't, and the library has no way to know which. Sliding-window
+prefetch and its cancellation were verified only against an in-memory test double, never against
+the real native download stack on a real phone, so a device-only failure mode (partial writes,
+a `.cancel()` that doesn't actually stop the transfer) would currently ship undetected. And an
+Expo developer opening `example-expo/` sees a single hard-coded video where a bare-RN developer
+opens `example/` and sees a scrolling list wired to the library's own prefetch hook — the one
+feature this roadmap exists to harden has no first-party Expo reference at all, and nothing in
+CI would catch a regression in the Expo demo even if one were added.
+
+**Desired outcome:** the four items v0.5.0's own README already marks "known limitation, not a
+wish list" are closed, and an Expo developer gets the same demo-quality reference a bare-RN
+developer already has, with CI holding it there.
+
+**Anti-goals:** no new caching capability, no new protocol surface, no architecture change — see
+Non-Goals below. This is a hardening + parity pitch, not a features pitch.
+
+## Appetite
+
+~1.5–2 weeks, split as the roadmap author bundled it:
+- W0 (hardening backlog) — ~1 week
+- W1 (bare/Expo demo parity) — ~3–4 days
+
+Bundled as one Betting Table pitch because both waves are small, additive, gate nothing else in
+the roadmap, and touch disjoint parts of the tree (W0: `src/`; W1: `example-expo/` +
+`.github/workflows/`) — there's no reason to spend two separate betting cycles on them.
+
+## Requirements
+
+R0: A consumer app can configure a custom cache-key policy (`denylistParams` and/or
+`urlKeyExtractor`) once, and have it honored everywhere the library derives a cache key or an
+on-disk path — not just at one call site.
+
+R1: A consumer app can import the cache-status event name from the package entry point and
+subscribe to it, without hardcoding the `'RNCV_CACHE_STATUS'` string.
+
+R2: A player that issues a byte-range request for content already fully cached from an earlier
+identical ranged request receives `206` plus a `Content-Range` header describing the correct
+total resource length — not `200`.
+
+R3: An asset already cached before this ships (no total length on record) keeps answering a
+ranged request with today's `200` behavior — no crash, no forced re-download, no silent data
+loss.
+
+R4: Sliding-window prefetch (`usePrefetch` / `setActiveWindow`) is exercised on one physical iOS
+device and one physical Android device, against the real native download stack, and the result
+(pass, or a filed bug) is recorded — not asserted from the jest mock alone.
+
+R5: `PrefetchWindow.cancel()` is exercised on the same two physical devices and confirmed to
+actually stop the underlying native transfer (or a filed bug records that it doesn't) — not just
+confirmed to flip JS-side state to `'cancelled'`.
+
+R6: An Expo developer running `example-expo/` sees the same scrolling multi-video list, wired to
+`usePrefetch`, that a bare-RN developer already sees in `example/` — not only the single-video
+case.
+
+R7: A pull request that changes the library or `example-expo/` gets an automatic CI signal on
+whether `example-expo` still builds for Android — not only `example/`.
+
+(R0/R1/R6/R7 are close to solution language because they name existing, already-documented
+public API surface — `denylistParams`, `urlKeyExtractor`, `usePrefetch`, `example-expo` — not
+because a shape was smuggled in early; there's no vaguer way to state "export the thing that
+already has this name.")
+
+## Rabbit Holes
+
+- **RH1 — Threading the cache-key policy through every call site.** `CacheKeyPolicy.keyFor` /
+  `filePathFor` are called with no `policy` argument at roughly 15 sites across
+  `ProxyCacheManager.ts`, `PrefetchWindow.ts`, `PreCacheProvider.ts`, and `verifiedWrite.ts`. A
+  naive "add a `policy` param to `CacheManager`'s constructor and pass it down" would mean
+  touching all four files and re-verifying that a prefetch-time key and a playback-time key still
+  agree — that's a correctness-sensitive refactor of already-shipped code (RULE 3), not a
+  hardening fix, and it alone could eat the whole W0 budget. The shape below avoids it entirely
+  (A2).
+- **RH2 — Building device-automation infrastructure to "prove" R4/R5.** There is no Detox,
+  Maestro, or any on-device test runner in this repo today. Standing one up so the harness can
+  assert "prefetch works on hardware" automatically is a multi-week infrastructure bet on its
+  own — explicitly not what a ~1 week hardening wave can absorb. The shape treats R4/R5 as a
+  documented manual verification pass, not new CI (A4).
+- **RH3 — Registry schema creep.** `CacheEntry` is a versioned, persisted, discriminated union
+  (`REGISTRY_VERSION = 2`; a version bump discards every existing on-disk registry). Persisting a
+  total length is a one-field *additive* change — the rabbit hole is treating this as an excuse
+  to also "clean up" the registry shape while in the file. Out of scope; RULE 3 applies.
+- **RH4 — Fixing the Android in-memory-buffering workaround while touching the same files.**
+  W0's device-verification pass and the Content-Range fix both touch
+  `addSegmentHandler`/`verifiedWrite.ts`, the same neighborhood as the Android streamed-to-disk
+  problem the roadmap already scoped out as its own bet (W2). Do not fold it in here even if it's
+  tempting mid-file.
+
+## Non-Goals
+
+Carried forward from the roadmap and the prior cycle — still correct, not reopened by this pitch:
+- No JS-side HLS decoder or ABR engine — decode and bitrate switching stay AVPlayer's/ExoPlayer's
+  job.
+- No Expo Go support — the localhost HTTP proxy is a custom TurboModule by definition; dev-client
+  + prebuild stays the supported Expo path.
+- No DASH — hls.js itself is HLS-only; matching its surface doesn't imply matching Shaka's.
+- No sparse byte-range span storage (ExoPlayer `SimpleCache`-style) — whole-file range-suffixed
+  variants stay the bounded shape; this pitch only fixes the `Content-Range` *header*, never the
+  storage model.
+- No Android streamed-to-disk fix (the in-memory-buffering workaround stays as-is) — that's W2,
+  its own bet, specifically because it shares a bridge surface with this pitch's W0 and the
+  roadmap says not to fold it in.
+- No W3–W6 roadmap items (proxied-surface registration, live/EVENT playlists, CDN-failover/CMCD,
+  observability counters) — separate bets.
+
+## Selected Shape — Additive Hardening, No New Call-Site Surface
+
+Rationale: every R in this pitch is closing a gap the codebase already names (README's "Known
+limitations," the roadmap's G1/G2 ledger) rather than adding a new capability. The unifying
+principle across all six parts is the same one RULE 2/RULE 3 push toward: the smallest change
+that makes the existing, already-written logic reachable, never a rewrite of it. Two shapes were
+considered and rejected before this one:
+
+- *Thread a policy object through every constructor* (rejected — RH1; large blast radius for a
+  ~1 week wave, real risk of a cache-identity mismatch bug).
+- *Build Detox/Maestro device automation now* (rejected — RH2; a multi-week bet the roadmap
+  hasn't scheduled, and this pitch's appetite can't absorb it).
+
+### Parts
+
+A1: **Package-entry export surface** — re-export `keyFor`, `filePathFor`, `normalizeCacheKey`,
+`CacheKeyPolicyOptions`, `DEFAULT_DENYLIST_PARAMS` (from `Utils/cacheKeyPolicy.ts`) and
+`CACHE_STATUS_EVENT` + `CacheStatus` (from `ProxyCacheManager.ts`, aliased as `RNCV_CACHE_STATUS`
+in the export) from the package's named export list — zero behavior change for any existing
+caller, pure additive export.
+
+A2: **Module-level default cache-key policy** — a new `setDefaultCacheKeyPolicy(policy)` /
+`getDefaultCacheKeyPolicy()` pair inside `cacheKeyPolicy.ts` itself; `normalizeCacheKey` falls
+back to the configured default only when a call site passes no explicit `policy` (which is every
+existing call site today). Every one of the ~15 existing `keyFor`/`filePathFor` calls honors a
+configured policy for free, with no call-site edits and byte-identical default behavior when
+nothing is configured (avoids RH1 entirely).
+
+A3: **Persisted total-resource-length on ranged promote** — when a ranged origin fetch's response
+carries `Content-Range` (already parsed today as `WriteTempResult.contentRange`, just discarded
+after the response is sent) or an unranged fetch carries `Content-Length`, record the resource's
+total byte length as one new optional field on the owning registry entry (additive; no
+`REGISTRY_VERSION` bump — an entry with the field absent is exactly the pre-0.5.1 shape). The
+cache-HIT branch in `addSegmentHandler` (today: unconditional `sendRaw(200, ...)`) parses the
+current request's own `Range` header the same way `absoluteFilePath` already does, looks up the
+recorded total, and when both are present answers `206` + a reconstructed `Content-Range`;
+otherwise it answers exactly as it does today (A3 covers both R2 and R3 by construction — the
+fallback isn't a separate code path, it's what "total absent" already does).
+
+A4: **Device-verification runbook** — a step-by-step, repeatable manual test script (run against
+`example/` — no new app needed) exercising `usePrefetch`'s sliding window and
+`PrefetchWindow.cancel()`, executed once against one physical iOS device and one physical Android
+device, with a pass/fail per platform recorded directly in the runbook. Closes R4/R5 as a
+documentation + verification-log deliverable, not new test infrastructure (avoids RH2).
+
+A5: **example-expo demo parity** — mirror `example/src/components/VideoList.tsx` (+`VideoItem.tsx`
+if not already present in `example-expo/`) and its data fixtures (`data/streams.ts`) into
+`example-expo/src/`, wired the same way `example/`'s own `VideoList.tsx` already wires
+`usePrefetch` — same component, same data, same hook call, adapted only where the two apps'
+existing structure already differs (e.g. `example-expo` has no `data/videos.ts`, only
+`streams.ts` needs mirroring).
+
+A6: **example-expo CI build job** — a new CI job mirroring `ci.yml`'s existing `build-android` job:
+run `expo prebuild` (Android target) then `./gradlew assembleDebug` inside `example-expo/`,
+cached the same way the existing job caches Gradle/turbo. The Expo config plugin this depends on
+already shipped and is documented working (0.4.0 cycle) — this job exercises it in CI for the
+first time, it doesn't newly build it.
+
+## Fit Check
+
+| R# | Requirement | Covered by | Status |
+|----|-------------|------------|--------|
+| R0 | Configurable cache-key policy, honored everywhere | A1, A2 | ✅ |
+| R1 | `RNCV_CACHE_STATUS` importable, no hardcoded string | A1 | ✅ |
+| R2 | Ranged cache-hit answers 206 + correct Content-Range | A3 | ✅ |
+| R3 | Pre-existing cached asset keeps answering 200 safely | A3 | ✅ |
+| R4 | Prefetch device-verified (iOS + Android hardware) | A4 | ✅ |
+| R5 | `.cancel()` device-verified (iOS + Android hardware) | A4 | ✅ |
+| R6 | example-expo shows the VideoList/usePrefetch demo | A5 | ✅ |
+| R7 | CI builds example-expo for Android on every PR | A6 | ✅ |
+
+No R is uncovered or partial. R4/R5's coverage is a documented manual verification process, not
+an automated assertion — see Spike Results below for why that's the deliverate scope, not a gap.
+
+## Spike Results
+
+No `SPIKE-UNRESOLVED` items. This pitch's shape was grounded directly against the current code
+(not invented against the README's prose), and every technical question that would normally need
+a spike was answered by reading the actual call sites before writing the shape:
+
+- **Is the cache-key policy genuinely wired nowhere?** Confirmed — `grep` across the repo shows
+  every `CacheKeyPolicy.keyFor(...)` / `filePathFor(...)` call site (`ProxyCacheManager.ts`
+  lines 314/325/344/442/623/645/803/945, `PrefetchWindow.ts` lines 518/653/721/799,
+  `PreCacheProvider.ts` line 103/249, `verifiedWrite.ts` line 156) passes no `policy` argument.
+  `src/Utils/index.ts` re-exports only `util` and `constants`, never `cacheKeyPolicy` — so A1/A2's
+  premise is accurate, not assumed.
+- **Does a ranged cache-hit really always answer 200, with no ambiguity about which range?**
+  Confirmed — `addSegmentHandler`'s hit branch (`ProxyCacheManager.ts` ~line 1075) calls
+  `sendRaw(200, HLS_VIDEO_TYPE, streamData)` unconditionally, and the file it reads is already the
+  range-*suffixed* path (`absoluteFilePath` derives `<file>-<offset>-<length>.<ext>` from the
+  CURRENT request's own `Range` header before the hit check runs) — so a hit is always an exact
+  repeat of a previously-satisfied range; offset/length are already known from the current
+  request, only the total was ever missing. A3's shape has no unresolved edge case.
+  `WriteTempResult.contentRange` (`verifiedWrite.ts` line 38) already carries the origin's
+  `Content-Range` on a ranged miss today — it's parsed and then discarded after the response is
+  sent (`ProxyCacheManager.ts` ~line 1156); A3 is "stop discarding it," not new parsing.
+- **Does the cache-HIT branch require an HLS "owner" to exist (as the MISS branch does)?**
+  Confirmed no — the hit branch's `sendRaw(200, ...)` runs regardless of `ownerKey`;
+  `registerSegmentUnderOwner` is only called *if* an owner exists. So A3's fix applies uniformly
+  to HLS segments and plain-MP4 repeat-hits alike, with no branch that needs special-casing.
+  (A pre-existing, unrelated gate — a plain MP4's very *first* ranged fetch 404s without a prior
+  HLS-owner or pre-cache call — was found during this read and is *not* touched: it's existing
+  0.5.0 behavior, out of this pitch's explicit scope, RULE 3.)
+- **Is there device-automation tooling already in the repo that R4/R5 could plug into?** Confirmed
+  no — no Detox, Maestro, or e2e config anywhere in the tree. A4's manual-runbook shape is the
+  actual state of the art here, not a shortcut.
+- **Does the Expo config plugin already work, or would CI wiring (A6) be discovering a new
+  problem?** Confirmed working — `example-expo/android` and `example-expo/ios` (gitignored,
+  regenerable) already exist on disk from a prior local `expo prebuild` run, and the 0.4.0 cycle
+  shipped + documented the config plugin (scoped loopback exceptions) as the supported Expo
+  install path. A6 is wiring CI around a working mechanism, not spiking a new one.
+
+## Open Questions for Betting Table
+
+- OQ1 — Cache-key policy config API: OK to ship as a module-level `setDefaultCacheKeyPolicy()` call
+  (zero call-site changes, but a global rather than a `CacheManagerProvider` prop) for this
+  pitch's appetite, or is a provider-prop API (larger touch surface, ~15 call sites) worth the
+  extra time even at hardening-pitch size?
+- OQ2 — Registry backward-compat: OK for a ranged cache-hit on an asset cached before this ships
+  (no total length on record) to keep answering `200` until it's naturally re-fetched, with no
+  forced cache invalidation/migration pass?
+- OQ3 — Device-verification deliverable: since no on-device/e2e automation exists in this repo, is
+  a documented manual runbook (run by a person with physical iOS/Android hardware, pass/fail
+  recorded in the doc) an acceptable Betting-Table deliverable for R4/R5 — or does "device
+  verified" require someone to actually run it and report results back before L4 sign-off blocks
+  on that?
+- OQ4 — example-expo CI scope: mirror `example/`'s CI exactly (Android debug build only, no iOS
+  job — bare RN doesn't have one either) — confirmed, or is an iOS CI job wanted specifically for
+  example-expo?
+- OQ5 — example-expo demo placement: mirror `example/`'s own `App.tsx` precedent exactly
+  (`SingleVideo` mounted by default, `VideoList` present as a swappable component, matching how
+  bare `example/` currently keeps `VideoList` commented out in favor of `SingleVideo`) rather than
+  making `VideoList` the Expo app's default view — OK?

--- a/shapeup/hardening-expo-parity/spec/_index.md
+++ b/shapeup/hardening-expo-parity/spec/_index.md
@@ -1,0 +1,161 @@
+---
+type: pitch
+feature: hardening-expo-parity
+appetite: "~1.5-2 weeks (W0 ~1 week hardening + W1 ~3-4 days bare/Expo demo parity)"
+status: ready
+bounded_context: cache-hardening
+entities: [CacheKeyPolicy, CacheEntry, SegmentTotalLengthRecord, CacheStatusEvent]
+tags: [hardening, expo-parity, cache-key-policy, content-range, device-verification, ci]
+skill_version: "4.0"
+audit_rules_version: "4.0"
+---
+
+# Pitch: 0.5.1 Hardening + Expo Parity
+
+## Problem
+v0.5.0 shipped and closed the headline caching bugs, but four items its own README already
+marks "known limitation, not a wish list" stayed open, and `example-expo/` was left behind
+`example/` in demo fidelity and CI coverage. A host app cannot configure a cache-key policy or
+subscribe to cache-status events by name; a player that re-requests already-cached ranged bytes
+gets `200` instead of `206`/`Content-Range`; sliding-window prefetch and its cancellation were
+never verified against the real native download stack on a physical device; and an Expo
+developer sees a single hard-coded video where a bare-RN developer sees a scrolling
+`usePrefetch`-wired list, with no CI signal if that demo regresses.
+
+## Appetite
+**~1.5-2 weeks**, split as the roadmap author bundled it: W0 (hardening backlog, `src/`) ~1
+week, W1 (bare/Expo demo parity, `example-expo/` + `.github/workflows/`) ~3-4 days. Bundled as
+one Betting Table pitch because both waves are small, additive, gate nothing else in the
+roadmap, and touch disjoint parts of the tree. If scope grows beyond this, GATE H ships what's
+green and cuts the rest — the timeline does not extend.
+
+## Boundaries
+
+### In Scope
+- R0: configurable cache-key policy (`denylistParams` / `urlKeyExtractor`), honored everywhere
+  the library derives a key or path, with zero call-site edits (A1 export + A2 module-level
+  default).
+- R1: `RNCV_CACHE_STATUS` importable from the package entry point (A1).
+- R2/R3: a ranged cache-hit answers `206` + correct `Content-Range` when the total resource
+  length is on record; an asset cached before this ships (no total on record) keeps answering
+  `200` — no crash, no forced re-download (A3).
+- R4/R5: `usePrefetch`/`setActiveWindow` and `PrefetchWindow.cancel()` exercised on one physical
+  iOS device and one physical Android device against the real native stack, pass/fail recorded
+  in a runbook (A4).
+- R6: `example-expo/` gets the same scrolling `usePrefetch`-wired `VideoList` demo `example/`
+  already has (A5).
+- R7: CI builds `example-expo` for Android on every PR that touches the library or the app (A6).
+
+### Non-Go
+- No new caching capability, no new protocol surface, no architecture change — this is a
+  hardening + parity pitch.
+- No provider-prop cache-key API (OQ1 resolved: module-level `setDefaultCacheKeyPolicy()` only —
+  RH1's ~15-call-site threading is explicitly avoided).
+- No `REGISTRY_VERSION` bump, no `CacheEntry.segmentPaths` shape change beyond an additive
+  sibling structure (RH3).
+- No Detox/Maestro/on-device test automation — R4/R5 ship as a documented manual runbook, not
+  new CI (RH2).
+- No Android streamed-to-disk fix (`addSegmentHandler`/`verifiedWrite.ts` in-memory-buffering
+  workaround stays as-is) — that's W2, a separate bet (RH4).
+- No iOS CI job for `example-expo` — Android only, mirroring `example/`'s own CI (OQ4).
+- No JS-side HLS decoder/ABR, no Expo Go support, no DASH, no sparse byte-range span storage —
+  carried forward from the roadmap, not reopened here.
+
+## Solution Elements
+
+### Breadboarding
+```
+[Consumer app] ──setDefaultCacheKeyPolicy()──► [cacheKeyPolicy module-level default]
+                                                        │
+                                          (every existing keyFor/filePathFor
+                                           call honors it via ?? fallback,
+                                           zero call-site edits)
+
+[Player] ──ranged GET (repeat)──► [addSegmentHandler hit branch]
+                                          │
+                              total length on record? ──yes──► 206 + Content-Range
+                                          │
+                                          no (pre-existing asset) ──► 200 (today's behavior)
+
+[Expo developer] ──opens example-expo/──► [VideoList + usePrefetch, same as example/]
+[PR touching library or example-expo] ──► [CI: expo prebuild + gradlew assembleDebug]
+```
+
+### Key Interactions
+1. A consumer app calls `setDefaultCacheKeyPolicy({ denylistParams, urlKeyExtractor })` once at
+   startup; every subsequent cache-key/path derivation across the library honors it.
+2. A consumer app imports `RNCV_CACHE_STATUS` and subscribes via `DeviceEventEmitter` without
+   hardcoding the string.
+3. A player seeks into a range already fully cached from an earlier identical ranged request and
+   receives `206` + a correct `Content-Range` header.
+4. An Expo developer opens `example-expo/` and sees the same scrolling, prefetch-wired video list
+   a bare-RN developer sees in `example/`.
+5. A PR that touches the library or `example-expo/` gets a green/red Android build signal for
+   the Expo demo, same as `example/` already has.
+
+## Rabbit Holes (Risks)
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| RH1 — threading a policy object through ~15 call sites | avoided by design | A2's module-level default reuses the existing `policy?.` `??` fallback chain at zero call-site cost |
+| RH2 — building device-automation infra to "prove" R4/R5 | avoided by design | A4 is a documented manual runbook, not new CI/Detox/Maestro |
+| RH3 — registry schema creep while touching `CacheEntry` | mitigated | A3 stays additive: a scalar field for `kind: media`, a separate side-map (not a `CacheEntry` field, not a `segmentPaths` shape change) for `kind: hls` — no `REGISTRY_VERSION` bump |
+| RH4 — folding the Android in-memory-buffering fix into A3's same-neighborhood files | explicitly out of scope | W2 owns that fix; this pitch touches only what R2/R3 require |
+| A3's HLS case: orient's spike found the pitch's literal "one field on the owning entry" wording is wrong for `kind: hls` (one owner entry serves many segments with distinct totals) | resolved pre-board | [[usecases/UC-RangedCacheHitContentRange]]'s Steps/AC commit to the side-map shape, not the pitch's literal wording — see Spike Results below |
+
+## Spike Results
+
+Orient's `spike-content-range-persistence.md` re-opened A3 (rated "downhill" by the pitch's own
+Spike Results) after finding the stated shape correct for `CacheEntry.kind === 'media'` but
+architecturally wrong for `kind === 'hls'`: one owner entry is shared by every segment in
+`segmentPaths: string[]`, so a single scalar `totalLength` field on the owner cannot hold each
+segment's distinct total length. Two additive alternatives were traced; the lower-blast-radius
+option (a separate per-file side map, keyed by the range-suffixed path, persisted as its own
+top-level registry section — not a `CacheEntry` field, no `segmentPaths` shape change) is the one
+committed in [[usecases/UC-RangedCacheHitContentRange]]. `didEvictHandler`'s missing per-segment
+eviction hook (discovered-seed item 2) is carried into that UC's Steps as an explicit GC tie-in,
+not left as a silent leak.
+
+## Fit Check
+
+| R# | Requirement | Covered by | Status |
+|----|-------------|------------|--------|
+| R0 | Configurable cache-key policy, honored everywhere | [[usecases/UC-CacheKeyPolicyConfiguration]] | ✅ |
+| R1 | `RNCV_CACHE_STATUS` importable, no hardcoded string | [[usecases/UC-CacheStatusEventExport]] | ✅ |
+| R2 | Ranged cache-hit answers 206 + correct Content-Range | [[usecases/UC-RangedCacheHitContentRange]] | ✅ |
+| R3 | Pre-existing cached asset keeps answering 200 safely | [[usecases/UC-RangedCacheHitContentRange]] | ✅ |
+| R4 | Prefetch device-verified (iOS + Android hardware) | [[usecases/UC-DeviceVerifiedPrefetchCancellation]] | ✅ |
+| R5 | `.cancel()` device-verified (iOS + Android hardware) | [[usecases/UC-DeviceVerifiedPrefetchCancellation]] | ✅ |
+| R6 | example-expo shows the VideoList/usePrefetch demo | [[usecases/UC-ExpoVideoListParity]] | ✅ |
+| R7 | CI builds example-expo for Android on every PR | [[usecases/UC-ExpoCIBuildSignal]] | ✅ |
+
+## Document Map
+
+| Document | Type | Status |
+|----------|------|--------|
+| [[domain-model]] | DDD Model | ✅ ready |
+| [[ux-behavior]] | UX Spec | ✅ ready |
+| [[usecases/_index]] | Use Cases | ✅ ready |
+| [[integration]] | Integration Map | ✅ ready |
+| [[scope-summary]] | Scope Summary | ✅ ready |
+| [[synthesis]] | Health Dashboard + Traceability + Risk + Dependency | ✅ ready |
+| [[feedback]] | Post-Sprint Feedback | ⬜ pending |
+
+---
+
+## Audit Report
+
+*Generated from harness verify spec output — do not edit manually.*
+*skill_version: 4.0 | audit_rules_version: 4.0*
+
+### Score Summary
+
+`harness verify spec --slug hardening-expo-parity`: 12 tasks, **0 red, 1 warn**.
+
+### Execution Gate
+✅ Ready for execution — 0 red findings.
+
+### Issues Found
+- WARN `WIKILINK`: `ux-behavior.md → [[project-profile]]` unresolved in spec dir — expected
+  (`project-profile.md` lives one directory up, per this feature's own committed layout; the same
+  warn is accepted on the prior `hls-caching-features` spec for the identical reason).

--- a/shapeup/hardening-expo-parity/spec/domain-model.md
+++ b/shapeup/hardening-expo-parity/spec/domain-model.md
@@ -1,0 +1,167 @@
+---
+type: domain-model
+feature: hardening-expo-parity
+bounded_context: cache-hardening
+entities: [CacheEntry, SegmentTotalLengthRecord, CacheStatusEvent]
+value_objects: [CacheKeyPolicy, RangeSpec, TotalLength]
+domain_events: [CacheStatusEmitted]
+repositories: [CacheKeyPolicyStore, CacheRegistryRepository]
+tags: [ddd, hardening, w0, w1]
+depends_on: ["[[_index]]"]
+status: ready
+---
+
+# Domain Model: 0.5.1 Hardening + Expo Parity
+
+## Bounded Context
+`cache-hardening` — owns the module-level cache-key policy configuration
+(`src/Utils/cacheKeyPolicy.ts`), the persisted total-resource-length data needed to answer a
+repeat ranged request with `206`/`Content-Range` (`src/ProxyCacheManager.ts`'s registry +
+`addSegmentHandler`'s hit branch), and the package's public export surface for both
+(`src/index.tsx`, `src/Utils/index.ts`). It does NOT own cache-key *derivation logic* itself
+(`normalizeCacheKey`/`keyFor`/`filePathFor` already exist and are unchanged — this context only
+adds where their `policy` argument falls back to), eviction *policy* selection, or the native
+bridge transport. W1 (Expo demo parity + CI) is a separate, disjoint concern captured in
+[[integration]] rather than as domain aggregates — it has no persisted state or invariants of
+its own, only a mirroring/CI relationship to `example/`.
+
+This pitch adds no new bounded context — it closes gaps in contexts that already exist and
+already shipped in 0.5.0 (RULE 3: hardening, not a rewrite).
+
+---
+
+## Aggregate: CacheKeyPolicy
+
+**Aggregate Root:** `CacheKeyPolicy` (module-level singleton configuration, not persisted to
+disk — held in memory for the process lifetime)
+
+**Invariants:**
+- A call site that passes no explicit `policy` argument to `normalizeCacheKey`/`keyFor`/
+  `filePathFor` uses the module-level default when one is configured, and the pre-0.5.1 built-in
+  default (`DEFAULT_DENYLIST_PARAMS`, no `urlKeyExtractor`) when none is configured — byte-identical
+  default behavior is the explicit non-goal-preserving case (R0's "zero call-site edits").
+- A call site that DOES pass an explicit `policy` argument (none exist today, but the seam stays
+  open) is never overridden by the module-level default — explicit always wins over configured
+  default.
+- Setting a new default takes effect for every subsequent call; it never retroactively changes a
+  key/path already derived and persisted under the previous default (no migration, no
+  re-keying — an existing on-disk entry keeps resolving under whatever policy produced its key).
+
+```
+CacheKeyPolicy (module-level, in-memory)
+├── denylistParams: string[]           # falls back to DEFAULT_DENYLIST_PARAMS
+└── urlKeyExtractor?: (url: string) => string
+```
+
+**State Transitions:**
+```
+unconfigured (DEFAULT_DENYLIST_PARAMS, no extractor)
+    ──setDefaultCacheKeyPolicy(policy)──► configured (policy)
+    ──setDefaultCacheKeyPolicy(policy2)──► configured (policy2)   # last write wins, no merge
+```
+
+---
+
+## Aggregate: CacheEntry (extended)
+
+**Aggregate Root:** `CacheEntry` (unchanged identity — keyed by `CacheKeyPolicy.keyFor(url)`,
+one per HLS playlist owner or standalone media file; already exists, shipped in prior rounds)
+
+**Invariants:**
+- A `CacheEntry` with `kind: 'media'` records at most one total resource length — the value
+  observed on the ranged/unranged fetch that first populated it — and an entry with the field
+  absent behaves EXACTLY as before this pitch (undefined total = "not yet recorded", not an
+  error state; this is what makes the change additive with no `REGISTRY_VERSION` bump).
+- A `CacheEntry` with `kind: 'hls'` NEVER carries a scalar total-length field on the entry
+  itself — the entry is shared by every segment of the playlist, and different segments have
+  different total lengths; per-segment totals live in `SegmentTotalLengthRecord` instead (see
+  below). This is the corrected shape from orient's spike, superseding the pitch's literal
+  "one field on the owning entry" wording for the HLS case.
+- The cache-HIT response branch never fabricates a total length it did not itself observe on a
+  prior fetch — absence of a recorded total is answered with today's `200` (R3), never a guess.
+
+```
+CacheEntry (Aggregate Root, unchanged shape + one addition)
+├── kind: 'media' | 'hls'
+├── ...existing fields (unchanged)
+└── totalLength?: number       # NEW — kind: 'media' ONLY. Absent on kind: 'hls'
+                                # (its per-segment totals live in SegmentTotalLengthRecord).
+```
+
+---
+
+## Aggregate: SegmentTotalLengthRecord
+
+**Aggregate Root:** `SegmentTotalLengthRecord` (new — a per-file side structure, NOT a field on
+`CacheEntry`, NOT a change to `segmentPaths`' `string[]` shape)
+
+**Invariants:**
+- Keyed by the exact range-suffixed `absoluteFilePath` the disk-hit branch already resolves
+  today — the same string `addSegmentHandler` uses to read the cached bytes, so no new key
+  derivation is introduced.
+- Persisted as its own top-level section of the registry JSON document, sibling to the existing
+  `entries` / `lruCachedLocalFiles` sections — an old registry document simply has no such
+  section, and a lookup miss behaves exactly like "total not yet recorded" (additive, no
+  `REGISTRY_VERSION` bump).
+- A record is removed when its owning file is evicted or removed — `didEvictHandler`'s HLS path
+  (which today only receives the owner `CacheEntry`, never individual segment paths) gains the
+  segment-path list it evicts as the GC trigger for this structure, closing the leak orient's
+  spike flagged (discovered-seed item 2) rather than leaving it open.
+
+```
+SegmentTotalLengthRecord (registry-document-level side map)
+└── Map<absoluteFilePath: string, totalLength: number>
+```
+
+**State Transitions:**
+```
+absent (no entry for this path)
+    ──ranged/unranged fetch observes total (Content-Range or Content-Length)──► recorded
+    ──segment file evicted/removed──► absent (record deleted alongside the file)
+```
+
+---
+
+## Value Objects
+
+| Value Object | Fields | Invariants |
+|---|---|---|
+| `RangeSpec` | offset: number, length: number | Already derived today from the CURRENT request's own `Range` header by `absoluteFilePath` — unchanged by this pitch, cited here only because A3's response reconstruction combines it with `TotalLength` |
+| `TotalLength` | value: number | Non-negative integer; sourced only from an observed `Content-Range` (ranged fetch) or `Content-Length` (unranged fetch) response header — never computed, never guessed |
+
+---
+
+## Domain Events
+
+| Event | Emitted When | Payload Fields | Consumers |
+|---|---|---|---|
+| `CacheStatusEmitted` | Existing `emitCacheStatus` call sites (`ProxyCacheManager.ts`, e.g. line 1016) — unchanged trigger, this pitch only exports the event NAME (`CACHE_STATUS_EVENT`, declared `ProxyCacheManager.ts:155`) and the `CacheStatus` type from the package entry point | key, status (`'HIT' \| 'MISS' \| 'STALE-FALLBACK'`) | Any consumer app subscribing via `DeviceEventEmitter.addListener(RNCV_CACHE_STATUS, ...)` — today only reachable by hardcoding the string |
+
+---
+
+## Repository Interfaces
+
+```typescript
+// src/Utils/cacheKeyPolicy.ts — new module-level store, no persistence, process-lifetime only
+interface CacheKeyPolicyStore {
+  setDefaultCacheKeyPolicy(policy: CacheKeyPolicyOptions): void
+  getDefaultCacheKeyPolicy(): CacheKeyPolicyOptions | undefined
+}
+
+// src/ProxyCacheManager.ts — extends the existing registry load/save, additive sections only
+interface CacheRegistryRepository {
+  // existing methods unchanged (loadCacheFromStorage / saveCacheToStorage)
+  // NEW: total-length read/write, additive to the persisted JSON document
+  getTotalLength(kind: 'media', ownerKey: string): number | undefined
+  getSegmentTotalLength(absFilePath: string): number | undefined
+  setTotalLength(kind: 'media', ownerKey: string, total: number): void
+  setSegmentTotalLength(absFilePath: string, total: number): void
+  deleteSegmentTotalLength(absFilePath: string): void   // GC hook, called from didEvictHandler
+}
+```
+
+---
+
+## Related
+- [[ux-behavior]] — the two example-app integration surfaces where R2/R3/R6 become observable
+- [[usecases/_index]] — use cases that operate on these aggregates

--- a/shapeup/hardening-expo-parity/spec/feedback.md
+++ b/shapeup/hardening-expo-parity/spec/feedback.md
@@ -1,0 +1,86 @@
+---
+type: feedback
+feature: hardening-expo-parity
+sprint_date: YYYY-MM-DD
+po_spec_accuracy: ~        # Fill after sprint: 1-5
+dev_execution_accuracy: ~  # Fill after sprint: 1-5
+---
+
+# Post-Sprint Feedback: 0.5.1 Hardening + Expo Parity
+
+> Fill this document during sprint retro.
+> Scores feed into `.claude/metrics.md` and drive SKILL improvements.
+
+---
+
+## Scores
+
+| Dimension | Score (1–5) | Meaning |
+|-----------|-------------|---------|
+| PO Spec Accuracy | ~ | Did generated docs reflect what PO intended? |
+| Dev Execution Accuracy | ~ | Did tasks lead to correct implementation? |
+
+**Score guide:**
+- 5 — Perfect, no corrections needed
+- 4 — Minor gaps, handled without blocking
+- 3 — Moderate gaps, caused 1–2 clarification rounds
+- 2 — Significant misalignment, rework required
+- 1 — Spec was wrong, had to re-generate from scratch
+
+---
+
+## PO Notes
+
+*Fill after reviewing delivered implementation against original pitch intent.*
+
+**What the spec got right:**
+- ...
+
+**What was missing or wrong:**
+- ...
+
+**Did the appetite hold?**
+Estimated: 1.5-2 weeks | Actual: N weeks/days
+
+---
+
+## Dev Notes
+
+*Fill during retro — be specific about which parts of the spec caused friction.*
+
+**Specs that needed clarification mid-sprint:**
+
+| Spec | What was unclear | What was needed |
+|------|-----------------|-----------------|
+| [[usecases/UC-RangedCacheHitContentRange]] | [description] | [what would have helped] |
+
+**Specs that were well-written:**
+- ...
+
+**Domain model accuracy:**
+- [ ] `SegmentTotalLengthRecord` side-map shape matched reality once built
+- [ ] Invariants were correct
+- [ ] `CacheRegistryRepository` interface was usable as-is
+
+---
+
+## Improvement Signals
+
+*The most important section — drives SKILL v.next.*
+*Flag which reference file or template needs updating.*
+
+| Signal | Affects | Action |
+|--------|---------|--------|
+| [what was missing] | `references/[file].md` | [what to add/change] |
+| [what was wrong] | `assets/templates/[file].tmpl.md` | [what to fix] |
+
+---
+
+## Update metrics.md
+
+After filling this doc, update `.claude/metrics.md` with PO and Dev scores:
+
+```bash
+# The row for this feature should already exist from SKILL generation
+# Just fill in the PO* and Dev* columns
+```

--- a/shapeup/hardening-expo-parity/spec/integration.md
+++ b/shapeup/hardening-expo-parity/spec/integration.md
@@ -1,0 +1,173 @@
+---
+type: integration
+feature: hardening-expo-parity
+affected_services: [cache-key-identity, hls-registry-and-ingestion, expo-example-app, ci-workflows]
+domain_events_consumed: []
+domain_events_produced: [CacheStatusEmitted]
+tags: [integration, w0, w1]
+depends_on: ["[[domain-model]]", "[[usecases/_index]]"]
+status: ready
+---
+
+# Integration Map: 0.5.1 Hardening + Expo Parity
+
+## Impact Summary
+
+| System | Severity | Direction | Summary |
+|--------|----------|-----------|---------|
+| cache-key-identity (`Utils/cacheKeyPolicy.ts`, `Utils/index.ts`, `src/index.tsx`) | 🟢 | ↔ | Additive module-level default + export surface; zero call-site edits, zero behavior change when unconfigured |
+| hls-registry-and-ingestion (`ProxyCacheManager.ts`) | 🔴 | ↔ | Persists a new total-length data point (entry field for media, side-map for HLS) and reads it on the hit branch; the one part touching the versioned registry |
+| expo-example-app (`example-expo/`) | 🟡 | ← consumes | New VideoList demo screen, no library API changes required |
+| ci-workflows (`.github/workflows/ci.yml`) | 🟢 | → produces | New job mirroring an existing pattern; isolated addition, distinct cache key |
+
+---
+
+## cache-key-identity (`Utils/cacheKeyPolicy.ts`, `Utils/index.ts`, `src/index.tsx`)
+
+**Severity:** 🟢 Isolated
+**Direction:** ↔ (produces the new default seam, consumed by all existing call sites)
+
+### What Changes
+`cacheKeyPolicy.ts` gains a module-level `setDefaultCacheKeyPolicy`/`getDefaultCacheKeyPolicy`
+pair; `normalizeCacheKey`'s existing `policy?.` `??` fallback chain (lines 63, 94) is widened to
+check the module default before the built-in default. `Utils/index.ts` and `src/index.tsx`
+re-export the policy symbols, `CACHE_STATUS_EVENT` (aliased `RNCV_CACHE_STATUS`), and
+`CacheStatus`.
+
+### Data Flow
+```
+[Consumer app] ──setDefaultCacheKeyPolicy(policy)──► [cacheKeyPolicy.ts: module-level var]
+                                                              │
+[~15 existing call sites, unedited] ──keyFor(url)/filePathFor(url)──► [normalizeCacheKey]
+                                                              │
+                                                     policy?. ?? getDefaultCacheKeyPolicy() ?? DEFAULT_DENYLIST_PARAMS
+```
+
+### Risk
+A bug in the fallback ordering (module default checked AFTER the built-in default instead of
+before) would silently make `setDefaultCacheKeyPolicy` a no-op for every existing call site —
+correct-looking code, wrong runtime behavior, invisible without a targeted test.
+
+### Mitigation
+[[usecases/UC-CacheKeyPolicyConfiguration]] TS-INV-01/02/03 pin the fallback ORDER explicitly
+(explicit policy > module default > built-in default), not just its existence.
+
+### Related Use Cases
+- [[usecases/UC-CacheKeyPolicyConfiguration]]
+- [[usecases/UC-CacheStatusEventExport]]
+
+---
+
+## hls-registry-and-ingestion (`ProxyCacheManager.ts`)
+
+**Severity:** 🔴 Blocking (highest-risk area of this pitch — the one part touching the
+versioned, persisted registry)
+**Direction:** ↔ (produces the persisted total-length data, consumes it on the hit branch)
+
+### What Changes
+`addSegmentHandler`'s disk-hit branch gains a total-length lookup + conditional `206` response;
+the registry's persisted JSON document gains one optional field on `kind: media` entries and one
+new additive top-level section (`SegmentTotalLengthRecord` side map) for `kind: hls` segments;
+`didEvictHandler`'s HLS path gains a GC tie-in to delete stale side-map entries on eviction.
+
+### Data Flow
+```
+[origin fetch, ranged/unranged MISS] ──Content-Range/Content-Length──► [persist total]
+                                                                             │
+                                                            kind:media → CacheEntry.totalLength
+                                                            kind:hls   → SegmentTotalLengthRecord[absFilePath]
+                                                                             │
+[player ranged GET, repeat] ──► [addSegmentHandler hit branch] ──lookup total──► 206 + Content-Range
+                                                                    (or 200 if total absent — R3)
+
+[didEvictHandler: HLS segment evicted] ──► [SegmentTotalLengthRecord entry deleted]
+```
+
+### Risk
+Landing the pitch's literal "one field on the owning entry" wording for `kind: hls` would
+silently mis-serve `Content-Range` for every segment past the first cached under a given
+playlist — a correctness bug that would ship undetected without a per-segment test (orient's
+spike finding). A missed eviction GC tie-in would leak stale side-map entries indefinitely
+without ever causing a visible failure.
+
+### Mitigation
+[[usecases/UC-RangedCacheHitContentRange]]'s Steps and Invariants commit to the side-map shape
+explicitly (INV-03), and its INV-05 + Steps 6 make the eviction GC tie-in an explicit,
+test-surfaced requirement rather than a silent gap. No `REGISTRY_VERSION` bump — both additions
+degrade to "absent = not yet recorded" on old documents (INV-04/R3).
+
+### Related Use Cases
+- [[usecases/UC-RangedCacheHitContentRange]]
+
+---
+
+## expo-example-app (`example-expo/`)
+
+**Severity:** 🟡 Consumer-facing, no library API risk
+**Direction:** ← consumes
+
+### What Changes
+`example-expo/src/` gains `VideoList.tsx`/`VideoItem.tsx`/`data/streams.ts`, mirrored from
+`example/`; `App.tsx` wires `VideoList` as a swappable component per OQ5.
+
+### Data Flow
+```
+[example/ (source, unchanged)] ──mirror──► [example-expo/src/ (new files)]
+                                                    │
+                                        [example-expo/App.tsx: VideoList wired, swappable]
+```
+
+### Risk
+A mirror that silently drifts from `example/`'s `usePrefetch` call shape would demo a stale or
+incorrect API surface to Expo developers specifically — the audience least likely to also read
+`example/`'s source to notice the drift.
+
+### Mitigation
+[[usecases/UC-ExpoVideoListParity]] INV-01 pins the hook-call-shape identity as a test-surfaced
+invariant, not just a one-time copy.
+
+### Related Use Cases
+- [[usecases/UC-ExpoVideoListParity]]
+
+---
+
+## ci-workflows (`.github/workflows/ci.yml`)
+
+**Severity:** 🟢 Isolated
+**Direction:** → produces
+
+### What Changes
+A new job (`build-android-expo` or similar) mirroring the existing `build-android` job's
+`expo prebuild` → `gradlew assembleDebug` steps, triggered on `src/**` or `example-expo/**`
+changes, with its own distinct Gradle/turbo cache key.
+
+### Data Flow
+```
+[PR: src/** or example-expo/** changed] ──► [build-android-expo job] ──► [pass/fail status check]
+```
+
+### Risk
+Sharing `build-android`'s exact cache key would let the two jobs silently corrupt each other's
+cached Gradle/turbo state — a flaky-looking failure with no obvious cause.
+
+### Mitigation
+[[usecases/UC-ExpoCIBuildSignal]] INV-01 requires the new job's cache key be verified distinct
+from `build-android`'s before the job is considered done.
+
+### Related Use Cases
+- [[usecases/UC-ExpoCIBuildSignal]]
+
+---
+
+## Event Coordination
+
+| Event | Producer | Consumers | Deploy Order |
+|-------|----------|-----------|-------------|
+| `CacheStatusEmitted` (`CACHE_STATUS_EVENT` / `RNCV_CACHE_STATUS`) | existing `emitCacheStatus` call sites (unchanged) | any consumer app subscribing via the newly-exported name | n/a — export-surface-only change, no deploy ordering constraint |
+
+---
+
+## Environment Variables Required
+
+None — this pitch introduces no new environment variables, third-party services, or sandbox
+accounts.

--- a/shapeup/hardening-expo-parity/spec/scope-summary.md
+++ b/shapeup/hardening-expo-parity/spec/scope-summary.md
@@ -1,0 +1,130 @@
+---
+type: scope-summary
+feature: hardening-expo-parity
+generated_at: 2026-08-21
+total_tasks: 12
+total_estimated_hours: 31
+packages_touched: [src/Utils, src, src/ProxyCacheManager, src/__tests__, docs, example-expo, .github/workflows]
+critical_path_length: 3
+critical_path_tasks: []
+external_blockers: [physical-ios-device-for-device-verification-runbook, physical-android-device-for-device-verification-runbook]
+audit_score: 0
+---
+
+# Feature Scope Summary: 0.5.1 Hardening + Expo Parity
+
+> Generated from `harness reduce board`. Board covers BUILD only — EVAL, device-verification
+> execution (beyond writing/running the A4 runbook once per platform), QA, GATE H, and ship
+> sign-off are subsequent run phases, not board tasks.
+> Audit score below 90 means spec needs human review before execution.
+
+---
+
+## At a Glance
+
+| | |
+|---|---|
+| Total tasks | 12 (10 FEAT/FIX + 1 DOCS + 1 CI/CHORE) |
+| Estimated effort | 31h (~4 days) |
+| Packages touched | 7 |
+| Critical path depth | 3 tasks |
+| External blockers | 2 (physical iOS + Android hardware, required for the device-verification runbook's execution) |
+| Spec audit score | pending `harness verify spec` |
+
+---
+
+## Critical Path
+
+The longest sequential chain — minimum time to complete if parallelized optimally.
+
+**Critical path estimate:** 11h total, 3 steps
+*(All other work — the R0/R1 export/policy chain, the R4/R5 device runbook, the R6/R7 Expo
+chain — runs in parallel alongside this chain)*
+
+The critical path runs entirely inside [[usecases/UC-RangedCacheHitContentRange]]'s three
+implementation steps (media/HLS total-length persistence → hit-branch wiring → integration
+test). The id-level chain lives on the LOCAL gitignored task board (per ADR-0001's two storage
+tiers), which renumbers per machine; read the id-level chain off that board itself, not this
+committed document.
+
+---
+
+## Package Distribution
+
+| Package | Tasks | Est. Hours | % of effort |
+|---------|-------|------------|--------------|
+| src/Utils | 1 | 2h | 6% |
+| src (export surface) | 2 | 3h | 10% |
+| src/ProxyCacheManager | 3 | 11h | 35% |
+| src/__tests__ | 2 | 5h | 16% |
+| docs | 1 | 3h | 10% |
+| example-expo | 2 | 4h | 13% |
+| .github/workflows | 1 | 3h | 10% |
+| **Total** | **12** | **31h** | 100% |
+
+---
+
+## Parallel Opportunities
+
+How much of the board can run simultaneously — **counts and use cases, never task ids.**
+
+| Group | Use cases | Tasks | Can start after |
+|-------|-----------|-------|-----------------|
+| Group A — cache-key policy (R0) | UC-CacheKeyPolicyConfiguration | 3 | nothing — no dependency |
+| Group B — cache-status event (R1) | UC-CacheStatusEventExport | 1 | nothing — no dependency |
+| Group C — Content-Range (R2/R3) | UC-RangedCacheHitContentRange | 4 | nothing (media- and HLS-kind total-length persistence run in parallel; hit-branch wiring waits on both; the integration test waits on hit-branch wiring) |
+| Group D — device runbook (R4/R5) | UC-DeviceVerifiedPrefetchCancellation | 1 | nothing — no dependency, no src/ touch |
+| Group E — Expo demo parity (R6) | UC-ExpoVideoListParity | 2 | nothing (Group A-D, disjoint tree) |
+| Group F — Expo CI (R7) | UC-ExpoCIBuildSignal | 1 | Group E (validates the demo it builds) |
+
+The per-scope release order is `scope-board.md`'s once scope-architect maps scopes; cite it
+rather than restating it here (this feature's board currently has 0 scope contracts —
+`scope-architect` runs after this document at MAP SCOPES).
+
+---
+
+## External Blockers
+
+Items that must be resolved BEFORE [[usecases/UC-DeviceVerifiedPrefetchCancellation]]'s runbook
+task can be marked done:
+
+**Physical Hardware**
+- [ ] One physical iOS device, available to execute the device-verification runbook
+- [ ] One physical Android device, available to execute the device-verification runbook
+
+**Environment Variables**
+- None.
+
+**Third-party Setup**
+- None — the Expo config plugin `example-expo/`'s prebuild depends on already shipped (0.4.0
+  cycle) and is confirmed working.
+
+**Internal Dependencies**
+- None across W0/W1 — the two waves touch disjoint parts of the tree by design (see
+  [[_index#Rabbit-Holes]]).
+
+---
+
+## Risks (from Pitch)
+
+Carried from [[_index#Rabbit-Holes]]:
+
+| Risk | Impact | Mitigation | Related UC |
+|------|--------|------------|-----------|
+| RH1 — threading a policy through ~15 call sites | high (would have eaten the whole W0 budget) | avoided by design — module-level default reuses the existing `??` fallback chain | [[usecases/UC-CacheKeyPolicyConfiguration]] |
+| RH2 — building device-automation infra for R4/R5 | high (multi-week bet, not this appetite) | avoided by design — documented manual runbook, not new CI | [[usecases/UC-DeviceVerifiedPrefetchCancellation]] |
+| RH3 — registry schema creep | medium (would force a `REGISTRY_VERSION` bump) | mitigated — additive field (media) + additive side-map (hls), no version bump | [[usecases/UC-RangedCacheHitContentRange]] |
+| RH4 — folding the Android in-memory-buffering fix into A3's neighborhood | medium (scope creep into W2's bet) | explicitly out of scope, called out in each A3 task's Non-Go | [[usecases/UC-RangedCacheHitContentRange]] |
+| A3's HLS shape (pitch's literal wording wrong for `kind: hls`) | high (would have silently mis-served Content-Range) | resolved pre-board — side-map shape committed in the UC and its tasks | [[usecases/UC-RangedCacheHitContentRange]] |
+
+---
+
+## Execution Recommendation
+
+<!-- Filled from harness verify spec output -->
+
+**Audit Score: pending**
+
+```
+[⚠️ Review recommended — PO + Dev walkthrough of A3's committed side-map shape before /execute-plan]
+```

--- a/shapeup/hardening-expo-parity/spec/synthesis.md
+++ b/shapeup/hardening-expo-parity/spec/synthesis.md
@@ -1,0 +1,129 @@
+---
+type: synthesis
+feature: hardening-expo-parity
+generated_at: 2026-08-21
+skill_version: "4.0"
+coverage_status: 🟢
+risk_status: 🟡
+dependency_status: 🟢
+depends_on:
+  - "[[domain-model]]"
+  - "[[ux-behavior]]"
+  - "[[usecases/_index]]"
+  - "[[scope-summary]]"
+---
+
+# Synthesis: 0.5.1 Hardening + Expo Parity
+
+> **How to use this document:**
+> Read the Health Dashboard first (30 seconds).
+> Each indicator tells you which section to open next — skip green sections.
+> 🟢 = no action needed · 🟡 = review recommended · 🔴 = must resolve before execution
+
+---
+
+## Health Dashboard
+
+| Indicator | Status | Signal |
+|-----------|--------|--------|
+| Coverage | 🟢 | Every UC has ≥1 covering task; no orphan tasks (all `use_case_refs` set) |
+| Risk | 🟡 | A3's HLS shape was re-opened and re-resolved pre-board (side-map, not a `CacheEntry` field) — worth a PO/Dev confirmation before BUILD; R4/R5's physical-device dependency is external, not code risk |
+| Dependency | 🟢 | Critical path is 3 tasks deep, entirely inside [[usecases/UC-RangedCacheHitContentRange]]; no single point of failure blocks more than 2 downstream tasks |
+
+### Execution Gate (Synthesis)
+
+⚠️ **REVIEW** — Risk is 🟡 (A3's corrected shape + external device dependency), Coverage and
+Dependency are 🟢.
+
+*Combine with Audit score gate: both must pass for autonomous `/execute-plan`.*
+
+---
+
+## S-01 — Traceability Matrix
+
+### UC × Task Coverage
+
+| Use Case | Actor | Covering Tasks | Status |
+|----------|-------|----------------|--------|
+| [[usecases/UC-CacheKeyPolicyConfiguration]] | Consumer App Developer | 3 | ✅ covered |
+| [[usecases/UC-CacheStatusEventExport]] | Consumer App Developer | 1 | ✅ covered |
+| [[usecases/UC-RangedCacheHitContentRange]] | System | 4 | ✅ covered |
+| [[usecases/UC-DeviceVerifiedPrefetchCancellation]] | Developer (manual runbook) | 1 | ✅ covered |
+| [[usecases/UC-ExpoVideoListParity]] | Expo Developer | 2 | ✅ covered |
+| [[usecases/UC-ExpoCIBuildSignal]] | PR Author | 1 | ✅ covered |
+
+### UC × Entity Participation
+
+| Use Case | Entity | Role |
+|----------|--------|------|
+| [[usecases/UC-CacheKeyPolicyConfiguration]] | `CacheKeyPolicy` | actor |
+| [[usecases/UC-CacheStatusEventExport]] | `CacheStatusEvent` | actor |
+| [[usecases/UC-RangedCacheHitContentRange]] | `CacheEntry` | actor |
+| [[usecases/UC-RangedCacheHitContentRange]] | `SegmentTotalLengthRecord` | actor |
+
+**Entity orphans (entities in domain-model with no UC reference):** none — every aggregate/value
+object in [[domain-model]] is referenced by at least one UC above.
+
+### Screen → UC Backing
+
+| Screen | Backed By | Status |
+|--------|-----------|--------|
+| SingleVideoPlayback | [[usecases/UC-RangedCacheHitContentRange]] | ✅ |
+| VideoListPrefetch | [[usecases/UC-DeviceVerifiedPrefetchCancellation]] | ✅ |
+| ExpoVideoListPrefetch | [[usecases/UC-ExpoVideoListParity]] | ✅ |
+
+### Domain Event Flow
+
+| Event | Emitted By UC | Consumer (integration.md) | Status |
+|-------|--------------|--------------------------|--------|
+| `CacheStatusEmitted` | [[usecases/UC-CacheStatusEventExport]] (export-surface only — trigger is pre-existing, unchanged) | [[integration#cache-key-identity]] | ✅ |
+
+---
+
+## S-02 — Risk Register
+
+### Rabbit Hole Register
+
+| Risk | From | Likelihood | Mitigation | Status |
+|------|------|-----------|------------|--------|
+| RH1 — thread policy through ~15 call sites | [[_index#Rabbit Holes]] | high | Module-level default reuses existing `??` fallback chain | ✅ mitigated |
+| RH2 — build device-automation infra for R4/R5 | [[_index#Rabbit Holes]] | high | Documented manual runbook, not new CI | ✅ mitigated |
+| RH3 — registry schema creep | [[_index#Rabbit Holes]] | medium | Additive field + additive side-map, no `REGISTRY_VERSION` bump | ✅ mitigated |
+| RH4 — fold Android in-memory-buffering fix into A3's neighborhood | [[_index#Rabbit Holes]] | medium | Explicitly out of scope in every A3 task's Non-Go | ✅ mitigated |
+| A3's `kind: hls` shape (pitch's literal wording wrong) | orient spike, [[_index#Rabbit Holes]] | high (would have silently mis-served every non-first segment) | Side-map shape committed in [[usecases/UC-RangedCacheHitContentRange]]'s Steps/Invariants and its covering task | ✅ mitigated |
+
+**Unmitigated risks:** none — every rabbit hole and the orient-surfaced A3 gap has a committed
+mitigation. R4/R5's physical-device availability remains an external dependency (see
+[[scope-summary#External-Blockers]]), not a design/code risk.
+
+### External Dependency Risks
+
+| Dependency | Declared In | Type | Unblock Condition |
+|------------|------------|------|------------------|
+| Physical iOS device | [[scope-summary#External-Blockers]] | hardware | available for the device-verification runbook's execution |
+| Physical Android device | [[scope-summary#External-Blockers]] | hardware | available for the device-verification runbook's execution |
+
+### Hammered Out (Cut)
+
+| Cut | At | Reason | Traded for (if any) |
+|-----|-----|-------|---------------------|
+| ~~Provider-prop cache-key API~~ | Betting Table (OQ1) | module-level `setDefaultCacheKeyPolicy()` chosen instead — smaller blast radius at this appetite | — |
+| ~~Detox/Maestro device automation~~ | Betting Table (RH2) | manual runbook chosen instead — multi-week infra bet the roadmap hasn't scheduled | — |
+| ~~iOS CI job for example-expo~~ | Betting Table (OQ4) | Android-only, mirroring `example/`'s own CI exactly | — |
+
+*A Cut is a healthy shaping signal, not debt. Revisit it at the betting table next cycle.*
+
+---
+
+## S-03 — Dependency Shape
+
+| Metric | Value |
+|---|---|
+| Critical path | 3 tasks · 11 hours · 35% of total estimated hours |
+| Widest parallel wave | 6 tasks — one each from UC-CacheKeyPolicyConfiguration, UC-CacheStatusEventExport, UC-RangedCacheHitContentRange (×2, the media and HLS total-length tasks), UC-DeviceVerifiedPrefetchCancellation, and UC-ExpoVideoListParity — all startable with no dependency |
+| Tasks with no dependency | 6 |
+| Single points of failure (block > 2 downstream) | 0 |
+
+**The per-scope build order lives in `scope-board.md`, not here** — `scope-architect` has not
+yet run for this feature (0 scope contracts on the board at generation time); cite that board
+once it exists, never restate it.

--- a/shapeup/hardening-expo-parity/spec/usecases/UC-CacheKeyPolicyConfiguration.md
+++ b/shapeup/hardening-expo-parity/spec/usecases/UC-CacheKeyPolicyConfiguration.md
@@ -1,0 +1,104 @@
+---
+type: usecase
+feature: hardening-expo-parity
+id: UC-CacheKeyPolicyConfiguration
+bounded_context: cache-hardening
+actor: Consumer App Developer
+entities: [CacheKeyPolicy]
+repositories: [CacheKeyPolicyStore]
+domain_events_emitted: []
+tags: [r0, scope-a1, scope-a2]
+depends_on: ["[[domain-model]]", "[[ux-behavior]]"]
+status: ready
+---
+
+# Use Case: Cache Key Policy Configuration
+
+## Summary
+A consumer app configures a custom cache-key policy (`denylistParams` and/or
+`urlKeyExtractor`) once via a new module-level setter, and every existing call site that derives
+a cache key or on-disk path honors it — without any call-site edits.
+
+## Preconditions
+- The consumer app has imported the package's public export surface (`src/index.tsx`).
+- `src/Utils/cacheKeyPolicy.ts`'s `normalizeCacheKey` already reads `policy?.denylistParams ??
+  DEFAULT_DENYLIST_PARAMS` (line 63) and `policy?.urlKeyExtractor` (line 94) — the exact seam
+  this UC's default slots into, confirmed by orient (zero signature change required).
+
+## Input
+
+```typescript
+interface SetDefaultCacheKeyPolicyInput {
+  policy: CacheKeyPolicyOptions   // { denylistParams?: string[]; urlKeyExtractor?: (url: string) => string }
+}
+```
+
+## Steps
+
+```
+1. Consumer app calls setDefaultCacheKeyPolicy(policy) once (e.g. at app startup), imported from
+   the package's public export surface.
+2. cacheKeyPolicy.ts stores `policy` in a module-level variable (process-lifetime, not
+   persisted).
+3. normalizeCacheKey's existing `policy?.denylistParams ?? DEFAULT_DENYLIST_PARAMS` (line 63)
+   and `policy?.urlKeyExtractor` (line 94) checks are widened to fall back to
+   `getDefaultCacheKeyPolicy()` BEFORE falling back to the built-in default — so any call that
+   passes no explicit `policy` argument (every one of the ~15 existing call sites today) picks
+   up the configured default automatically.
+4. Every existing keyFor/filePathFor call site (ProxyCacheManager.ts:314/325/344/442/623/645/
+   803/945, PrefetchWindow.ts:518/653/721/799, PreCacheProvider.ts:103/249, verifiedWrite.ts:156)
+   continues compiling and running unchanged — zero edits required at any of them.
+5. A consumer app that never calls setDefaultCacheKeyPolicy sees byte-identical default
+   behavior to 0.5.0 (DEFAULT_DENYLIST_PARAMS, no extractor).
+```
+
+## Output
+
+```typescript
+interface SetDefaultCacheKeyPolicyOutput {
+  // void — the setter has no return value; getDefaultCacheKeyPolicy() reads back the
+  // currently configured policy (or undefined if never set)
+}
+```
+
+## System Flow
+
+```
+[Consumer app: startup code]
+  → [import { setDefaultCacheKeyPolicy } from 'react-native-cache-video']
+    → [cacheKeyPolicy.ts: module-level policy variable set]
+      → [normalizeCacheKey (called by keyFor/filePathFor, ~15 existing call sites,
+         no call-site edits)]
+        ← [key/path derived using the configured policy]
+```
+
+## Invariants
+- [INV-01] A call site that passes an explicit `policy` argument is never overridden by the
+  module-level default — explicit always wins.
+- [INV-02] No call to `setDefaultCacheKeyPolicy` (the pre-0.5.1 state) produces byte-identical
+  key/path derivation to today's `DEFAULT_DENYLIST_PARAMS`-only behavior — zero regression for
+  every existing consumer that never opts in.
+- [INV-03] Setting a new default never retroactively re-keys or migrates an entry already
+  persisted under a previous default/policy.
+
+## Error Cases
+
+| Error Code | Condition | HTTP Status | Handling |
+|---|---|---|---|
+| n/a | `setDefaultCacheKeyPolicy` receives a malformed `policy` (e.g. `denylistParams` not an array) | n/a (synchronous JS call, not an HTTP path) | TypeScript typing prevents this at compile time for typed consumers; a runtime-untyped caller (plain JS) passing a non-array falls through to whatever `normalizeCacheKey`'s existing denylist-filtering logic already does with a non-array (no NEW runtime guard added — RULE 3, do not harden a path the pitch doesn't ask for) |
+
+## Test Surface
+
+| ID | Oracle | Probe | Expect | Source |
+|---|---|---|---|---|
+| TS-INV-01 | test | Call `keyFor(url, explicitPolicy)` after `setDefaultCacheKeyPolicy(differentPolicy)` is set | Key derived from `explicitPolicy`, not the module default | D1: INV-01 |
+| TS-INV-02 | test | Call `keyFor(url)` / `filePathFor(url)` with no `setDefaultCacheKeyPolicy` ever called | Key/path identical to the pre-0.5.1 `DEFAULT_DENYLIST_PARAMS`-only result (byte-for-byte) | D1: INV-02 |
+| TS-INV-03 | test | `keyFor(url)` under policy A → `setDefaultCacheKeyPolicy(policyB)` → re-derive key for an entry persisted under policy A | Persisted entry unaffected; no re-keying/migration attempted | D1: INV-03 |
+| TS-REQ-policy-denylistParams-empty | test | `setDefaultCacheKeyPolicy({ denylistParams: [] })` | Every query param retained in the key (no params stripped) — accepted, no crash | D3: Input shape |
+| TS-REQ-policy-urlKeyExtractor-only | test | `setDefaultCacheKeyPolicy({ urlKeyExtractor: fn })` with `denylistParams` omitted | `denylistParams` falls back to `DEFAULT_DENYLIST_PARAMS`; `urlKeyExtractor` honored | D3: Input shape |
+
+## Integration Points
+- → [[integration#cache-key-identity]] — the module-level default reused by all ~15 existing
+  call sites
+- ← [[ux-behavior]] — R0 has no screen of its own; observable only via `keyFor`/`filePathFor`
+  return values, not UI

--- a/shapeup/hardening-expo-parity/spec/usecases/UC-CacheStatusEventExport.md
+++ b/shapeup/hardening-expo-parity/spec/usecases/UC-CacheStatusEventExport.md
@@ -1,0 +1,94 @@
+---
+type: usecase
+feature: hardening-expo-parity
+id: UC-CacheStatusEventExport
+bounded_context: cache-hardening
+actor: Consumer App Developer
+entities: [CacheStatusEvent]
+repositories: []
+domain_events_emitted: [CacheStatusEmitted]
+tags: [r1, scope-a1]
+depends_on: ["[[domain-model]]", "[[ux-behavior]]"]
+status: ready
+---
+
+# Use Case: Cache Status Event Export
+
+## Summary
+A consumer app imports the cache-status event name (`RNCV_CACHE_STATUS`) and the `CacheStatus`
+type from the package entry point and subscribes to cache hit/miss events, without hardcoding
+the `'RNCV_CACHE_STATUS'` string.
+
+## Preconditions
+- `CACHE_STATUS_EVENT` (`= 'RNCV_CACHE_STATUS'`) is declared and already emitted today at
+  `src/ProxyCacheManager.ts:155` (declaration) and `:832` (`DeviceEventEmitter.emit`) — the
+  constant exists and fires correctly; only the package-entry re-export is missing.
+- `CacheStatus` (`'HIT' | 'MISS' | 'STALE-FALLBACK'`) is declared at `ProxyCacheManager.ts:156`.
+
+## Input
+
+```typescript
+// No runtime input — this UC is a static export surface change.
+// Consumer usage:
+import { RNCV_CACHE_STATUS, CacheStatus } from 'react-native-cache-video'
+DeviceEventEmitter.addListener(RNCV_CACHE_STATUS, (payload: { key: string; status: CacheStatus }) => { /* ... */ })
+```
+
+## Steps
+
+```
+1. src/index.tsx (or src/ProxyCacheManager.ts's existing named export block, whichever the
+   package root already re-exports from) adds `CACHE_STATUS_EVENT` aliased as `RNCV_CACHE_STATUS`
+   and the `CacheStatus` type to its export list.
+2. No change to emitCacheStatus or any existing emit call site — this UC is additive export
+   surface only, zero behavior change for any existing internal caller.
+3. A consumer app imports `RNCV_CACHE_STATUS` and subscribes via `DeviceEventEmitter`, receiving
+   the same payload shape the library has always emitted.
+```
+
+## Output
+
+```typescript
+interface CacheStatusEventExportOutput {
+  RNCV_CACHE_STATUS: string    // re-export of CACHE_STATUS_EVENT, value 'RNCV_CACHE_STATUS'
+  CacheStatus: 'HIT' | 'MISS' | 'STALE-FALLBACK'   // type-only export
+}
+```
+
+## System Flow
+
+```
+[ProxyCacheManager.ts: emitCacheStatus (unchanged, existing call sites)]
+  → [DeviceEventEmitter.emit(CACHE_STATUS_EVENT, { key, status })]  (unchanged)
+
+[Consumer app: import { RNCV_CACHE_STATUS } from package entry]  (NEW this pitch)
+  → [DeviceEventEmitter.addListener(RNCV_CACHE_STATUS, handler)]
+    ← [payload: { key, status }]
+```
+
+## Invariants
+- [INV-01] The exported `RNCV_CACHE_STATUS` value is byte-identical to the string a consumer
+  hardcoding `'RNCV_CACHE_STATUS'` today already uses — this UC changes reachability, never the
+  value, so no existing hardcoded-string consumer breaks.
+- [INV-02] No existing `emitCacheStatus` call site's behavior changes — this UC touches only the
+  package's export list.
+
+## Error Cases
+
+| Error Code | Condition | HTTP Status | Handling |
+|---|---|---|---|
+| n/a | This UC has no runtime error path — it is a compile-time export surface change only | n/a | n/a |
+
+## Test Surface
+
+| ID | Oracle | Probe | Expect | Source |
+|---|---|---|---|---|
+| TS-INV-01 | test | Import `RNCV_CACHE_STATUS` from the package entry point; compare to the literal string `'RNCV_CACHE_STATUS'` | Values are identical | D1: INV-01 |
+| TS-INV-02 | test | Trigger an existing cache-status emit path (e.g. a cache MISS) and subscribe via the newly-exported `RNCV_CACHE_STATUS` | Listener receives the same `{ key, status }` payload shape as subscribing via the hardcoded string today | D1: INV-02 |
+| TS-REQ-CacheStatus-type-exported | test | `import type { CacheStatus } from 'react-native-cache-video'` and assign a value outside `'HIT' \| 'MISS' \| 'STALE-FALLBACK'` | TypeScript compile error (type is exported and enforced) | D3: Output shape |
+
+## Integration Points
+- → [[integration#cache-key-identity]] — shares the same package-entry export-surface change as
+  [[usecases/UC-CacheKeyPolicyConfiguration]] (A1)
+- ← [[ux-behavior]] — R1 has no screen of its own; observable only via `DeviceEventEmitter`
+  subscription, not UI

--- a/shapeup/hardening-expo-parity/spec/usecases/UC-DeviceVerifiedPrefetchCancellation.md
+++ b/shapeup/hardening-expo-parity/spec/usecases/UC-DeviceVerifiedPrefetchCancellation.md
@@ -1,0 +1,113 @@
+---
+type: usecase
+feature: hardening-expo-parity
+id: UC-DeviceVerifiedPrefetchCancellation
+bounded_context: cache-hardening
+actor: Developer (manual runbook operator)
+entities: []
+repositories: []
+domain_events_emitted: []
+tags: [r4, r5, scope-a4, docs, manual-verification]
+depends_on: ["[[domain-model]]", "[[ux-behavior]]"]
+status: ready
+---
+
+# Use Case: Device-Verified Prefetch Cancellation
+
+## Summary
+A Developer executes a repeatable, step-by-step manual runbook against `example/`'s existing
+`VideoListPrefetch` screen on one physical iOS device and one physical Android device, verifying
+`usePrefetch`'s sliding window and `PrefetchWindow.cancel()` against the real native download
+stack, and records a pass/fail per platform directly in the runbook.
+
+## Preconditions
+- No Detox, Maestro, or e2e test-runner config exists anywhere in the repo (confirmed by orient
+  and by the pitch's own Spike Results) — this UC's deliverable is a documentation +
+  verification-log artifact, not new test infrastructure (avoids RH2).
+- `example/` already wires `usePrefetch`/`PrefetchWindow` (`VideoListPrefetch` screen,
+  unchanged by this pitch) — no new app is needed to exercise it.
+
+## Input
+
+```typescript
+interface DeviceRunbookInput {
+  platform: 'ios' | 'android'
+  deviceModel: string          // physical hardware, not a simulator/emulator
+  appBuild: string             // the example/ build under test
+}
+```
+
+## Steps
+
+```
+1. Write a step-by-step runbook (docs deliverable) covering:
+   a. Launch example/'s VideoListPrefetch screen on the target device.
+   b. Scroll to advance setActiveWindow's sliding window; observe (via device file inspector or
+      logging) that segments for the new window land on disk and stale-window segments are
+      evicted/not re-fetched.
+   c. Trigger PrefetchWindow.cancel() (e.g. rapid scroll away / unmount) and confirm — not just
+      that the JS-side state flips to 'cancelled' (already true today) — that the underlying
+      native transfer actually stops (no continued network activity / disk writes for the
+      cancelled URL after cancel() returns).
+2. Execute the runbook once against one physical iOS device.
+3. Execute the runbook once against one physical Android device.
+4. Record a pass/fail per platform directly in the runbook document, with enough detail
+   (device model, OS version, observed evidence) that another operator can reproduce or dispute
+   the result.
+5. Any failure found (partial writes, a cancel() that doesn't stop the transfer) is filed as a
+   bug via the discovery ledger — NOT silently fixed as part of this UC (R4/R5 ask for a
+   recorded result, not a guaranteed pass).
+```
+
+## Output
+
+```typescript
+interface DeviceRunbookOutput {
+  runbookDoc: string            // path to the written runbook + verification log
+  iosResult: 'pass' | 'fail — see filed bug'
+  androidResult: 'pass' | 'fail — see filed bug'
+}
+```
+
+## System Flow
+
+```
+[Developer: physical iOS device]
+  → [example/VideoListPrefetch: scroll, cancel]
+    → [PrefetchWindow: real native download stack (iOS)]
+      ← [observed: window advances / cancel stops transfer — logged in runbook]
+
+[Developer: physical Android device]
+  → [example/VideoListPrefetch: scroll, cancel]
+    → [PrefetchWindow: real native download stack (Android)]
+      ← [observed: window advances / cancel stops transfer — logged in runbook]
+```
+
+## Invariants
+- [INV-01] A pass/fail result exists in the runbook for BOTH platforms before this UC is
+  considered done — a runbook with no recorded execution is an incomplete deliverable, not a
+  pass.
+- [INV-02] A failure discovered during execution is filed as a bug (discovery ledger), never
+  silently patched by editing `PrefetchWindow`/native code inside this UC's own scope — that
+  would silently widen R4/R5 into a FIX task with no acceptance criteria of its own.
+
+## Error Cases
+
+| Error Code | Condition | HTTP Status | Handling |
+|---|---|---|---|
+| n/a | This UC's "failure" is a device-observation outcome, not an HTTP error — a failed
+  cancel()-doesn't-stop-transfer observation is the finding itself, not an exception path | n/a | Filed as a discovered bug per Step 5, runbook records "fail" with evidence |
+
+## Test Surface
+
+_No derivable surface — sources empty (no Error Cases, and Invariants here describe a manual
+documentation/execution process rather than a probeable system behavior). Exploratory coverage
+only (see qa-edge-hunter); the runbook's own pass/fail log is this UC's evidence, verified by the
+`docs` oracle (runbook file exists, contains a filled pass/fail section for both platforms) at
+build time._
+
+## Integration Points
+- → [[integration#full-lifecycle-integration]] — the runbook exercises the same
+  `usePrefetch`/`PrefetchWindow` code paths the existing test suite mocks
+- ← [[ux-behavior#VideoListPrefetch]] — the exact screen this runbook targets, unchanged by this
+  pitch

--- a/shapeup/hardening-expo-parity/spec/usecases/UC-ExpoCIBuildSignal.md
+++ b/shapeup/hardening-expo-parity/spec/usecases/UC-ExpoCIBuildSignal.md
@@ -1,0 +1,104 @@
+---
+type: usecase
+feature: hardening-expo-parity
+id: UC-ExpoCIBuildSignal
+bounded_context: cache-hardening
+actor: PR Author
+entities: []
+repositories: []
+domain_events_emitted: []
+tags: [r7, scope-a6, w1, ci]
+depends_on: ["[[domain-model]]", "[[ux-behavior]]", "[[usecases/UC-ExpoVideoListParity]]"]
+status: ready
+---
+
+# Use Case: Expo CI Build Signal
+
+## Summary
+A pull request that changes the library or `example-expo/` gets an automatic CI signal — a new
+job mirroring `ci.yml`'s existing `build-android` job — on whether `example-expo` still builds
+for Android, closing the gap where nothing in CI would catch a regression in the Expo demo.
+
+## Preconditions
+- `.github/workflows/ci.yml` already has a `build-android` job for bare `example/` — the pattern
+  to mirror (`expo prebuild` target Android → `./gradlew assembleDebug`, same Gradle/turbo cache
+  strategy) — confirmed working, not yet independently re-read line-by-line by orient (mechanical
+  risk only, to be confirmed at build time so the new job's cache key doesn't collide with the
+  bare-RN job's).
+- The Expo config plugin `example-expo`'s prebuild depends on already shipped and is documented
+  working (0.4.0 cycle) — `example-expo/android`/`ios` (gitignored, regenerable) already exist on
+  disk from a prior manual `expo prebuild` run. This UC wires CI around a working mechanism, not
+  spiking a new one.
+- [[usecases/UC-ExpoVideoListParity]] has landed `example-expo/`'s VideoList demo — the CI job
+  built here validates the fuller app, not just the pre-existing single-video case.
+
+## Input
+
+```typescript
+// No runtime input — this UC is a CI workflow change.
+// Trigger: any PR touching the library (`src/**`) or `example-expo/**`.
+```
+
+## Steps
+
+```
+1. Confirm ci.yml's existing build-android job's exact cache-key strategy (Gradle/turbo) before
+   writing the new job, so the two jobs' caches don't silently share (and corrupt) each other's
+   key.
+2. Add a new CI job (e.g. build-android-expo) to .github/workflows/ci.yml, triggered on PRs
+   touching src/** or example-expo/**, mirroring build-android's steps:
+   a. Checkout, install deps (same as build-android).
+   b. Run `expo prebuild` (Android target) inside example-expo/.
+   c. Run `./gradlew assembleDebug` inside example-expo/android.
+   d. Cache Gradle/turbo the same way build-android does, using a distinct cache key so the two
+      jobs never collide.
+3. Job reports a standard GitHub Actions pass/fail status check on the PR — same UX as
+   build-android already provides for example/.
+```
+
+## Output
+
+```typescript
+interface ExpoCIBuildSignalOutput {
+  jobName: string           // e.g. "build-android-expo"
+  triggersOn: string[]      // ["src/**", "example-expo/**"]
+  status: 'pass' | 'fail'   // per-PR CI check result
+}
+```
+
+## System Flow
+
+```
+[PR: touches src/** or example-expo/**]
+  → [GitHub Actions: build-android-expo job triggers]
+    → [expo prebuild (Android) inside example-expo/]
+      → [./gradlew assembleDebug]
+        ← [pass/fail status check posted to the PR]
+```
+
+## Invariants
+- [INV-01] The new job's cache key is distinct from `build-android`'s — a cache collision would
+  silently corrupt either job's build artifacts without failing loudly.
+- [INV-02] The job triggers on `example-expo/**` changes even when `src/**` is untouched — a
+  regression introduced purely inside `example-expo/` (e.g. UC-ExpoVideoListParity's own files)
+  is caught, not just library-side regressions.
+
+## Error Cases
+
+| Error Code | Condition | HTTP Status | Handling |
+|---|---|---|---|
+| n/a | `expo prebuild` or `gradlew assembleDebug` fails | n/a (CI job exit code, not HTTP) | Job reports a failing status check on the PR — no auto-merge-block change beyond what `build-android` already enforces for `example/` |
+
+## Test Surface
+
+| ID | Oracle | Probe | Expect | Source |
+|---|---|---|---|---|
+| TS-INV-01 | process | Inspect the new job's cache-key configuration in `ci.yml` against `build-android`'s | Keys are distinct (e.g. different cache-key prefix/suffix) | D1: INV-01 |
+| TS-INV-02 | process | Open a PR that touches only `example-expo/**` (no `src/**` change) | The new job triggers and reports a status check | D1: INV-02 |
+| TS-REQ-job-mirrors-steps | process | Diff the new job's steps against `build-android`'s | Same step shape (checkout, install, prebuild, gradlew assembleDebug), Android-only (no iOS step, per OQ4) | D3: Input/mirror shape |
+
+## Integration Points
+- → [[integration#expo-example-app]] — validates the demo [[usecases/UC-ExpoVideoListParity]]
+  lands
+- ← [[usecases/UC-ExpoVideoListParity]] — this UC's CI job is meaningless without that UC's
+  files present to build

--- a/shapeup/hardening-expo-parity/spec/usecases/UC-ExpoVideoListParity.md
+++ b/shapeup/hardening-expo-parity/spec/usecases/UC-ExpoVideoListParity.md
@@ -1,0 +1,99 @@
+---
+type: usecase
+feature: hardening-expo-parity
+id: UC-ExpoVideoListParity
+bounded_context: cache-hardening
+actor: Expo Developer
+entities: []
+repositories: []
+domain_events_emitted: []
+tags: [r6, scope-a5, w1]
+depends_on: ["[[domain-model]]", "[[ux-behavior]]"]
+status: ready
+---
+
+# Use Case: Expo VideoList Parity
+
+## Summary
+An Expo Developer opens `example-expo/` and sees the same scrolling multi-video list, wired to
+`usePrefetch`, that a bare-RN developer already sees in `example/` — not only the single-video
+case `example-expo/` shows today.
+
+## Preconditions
+- `example/src/components/VideoList.tsx` (+`VideoItem.tsx`) and `example/src/data/streams.ts`
+  exist and already wire `usePrefetch` (source of the mirror, confirmed by the pitch's own
+  reading).
+- `example/App.tsx` mounts `SingleVideo` by default with `VideoList` present but commented out
+  (the precedent OQ5 asks to mirror).
+- `example-expo/src/` has no `data/videos.ts` equivalent to mirror — only `streams.ts` needs
+  mirroring (pitch's confirmed state; this UC's build step re-confirms current file presence
+  before writing, since orient did not diff line-by-line).
+
+## Input
+
+```typescript
+// No runtime input — this UC is a file-mirroring + wiring change to the example-expo app.
+```
+
+## Steps
+
+```
+1. Confirm example-expo/src/'s current state (VideoList.tsx / VideoItem.tsx / streams.ts
+   present or absent) before mirroring — orient flagged this as not independently diffed.
+2. Mirror example/src/components/VideoList.tsx into example-expo/src/components/VideoList.tsx,
+   adapted only where the two apps' existing structure already differs.
+3. Mirror example/src/components/VideoItem.tsx into example-expo/src/components/VideoItem.tsx
+   IF not already present in example-expo/src/.
+4. Mirror example/src/data/streams.ts into example-expo/src/data/streams.ts.
+5. Wire example-expo/App.tsx per OQ5's confirmed precedent: SingleVideo mounted by default,
+   VideoList present as a swappable component (matching how example/'s own App.tsx keeps
+   VideoList commented out in favor of SingleVideo) — NOT making VideoList the Expo app's
+   default view.
+6. VideoList consumes usePrefetch identically to example/'s own VideoList — same hook call, same
+   component, same data shape.
+```
+
+## Output
+
+```typescript
+interface ExpoVideoListParityOutput {
+  filesAdded: string[]   // example-expo/src/components/VideoList.tsx, VideoItem.tsx (if new), data/streams.ts
+  appTsxWired: boolean    // VideoList reachable (swappable, per OQ5), not necessarily default-mounted
+}
+```
+
+## System Flow
+
+```
+[example/src/components/VideoList.tsx (source)]
+  → [mirror, adapted to example-expo/'s existing structure]
+    → [example-expo/src/components/VideoList.tsx (NEW)]
+      → [example-expo/App.tsx: VideoList wired as swappable component, per OQ5]
+        ← [Expo Developer: opens example-expo/, sees the same scrolling usePrefetch demo]
+```
+
+## Invariants
+- [INV-01] `example-expo/`'s mirrored `VideoList` calls the exact same `usePrefetch` hook
+  signature `example/`'s `VideoList` calls — no library API drift introduced by the mirror.
+- [INV-02] `example/`'s own `VideoList.tsx`/`VideoItem.tsx`/`streams.ts` are unchanged by this
+  UC — this is a one-directional mirror (example → example-expo), never a refactor of the
+  source.
+
+## Error Cases
+
+| Error Code | Condition | HTTP Status | Handling |
+|---|---|---|---|
+| n/a | This UC has no runtime error path of its own — it inherits whatever error handling
+  `example/VideoList` already has (unchanged by the mirror) | n/a | Inherited unchanged, per RULE-05 in [[ux-behavior]] |
+
+## Test Surface
+
+| ID | Oracle | Probe | Expect | Source |
+|---|---|---|---|---|
+| TS-INV-01 | process | Diff the `usePrefetch` call signature in `example-expo/src/components/VideoList.tsx` against `example/src/components/VideoList.tsx` | Identical hook call (same args, same shape) | D1: INV-01 |
+| TS-INV-02 | process | Diff `example/src/components/VideoList.tsx`/`VideoItem.tsx`/`data/streams.ts` before and after this UC's build | No changes to the source files | D1: INV-02 |
+| TS-REQ-streams-data-present | process | Load `example-expo/src/data/streams.ts` | Same stream URL fixtures as `example/src/data/streams.ts` | D3: Input/mirror shape |
+
+## Integration Points
+- → [[integration#expo-example-app]] — the consumer surface this UC populates
+- ← [[ux-behavior#ExpoVideoListPrefetch]] — the screen this UC creates

--- a/shapeup/hardening-expo-parity/spec/usecases/UC-RangedCacheHitContentRange.md
+++ b/shapeup/hardening-expo-parity/spec/usecases/UC-RangedCacheHitContentRange.md
@@ -1,0 +1,145 @@
+---
+type: usecase
+feature: hardening-expo-parity
+id: UC-RangedCacheHitContentRange
+bounded_context: cache-hardening
+actor: System
+entities: [CacheEntry, SegmentTotalLengthRecord]
+repositories: [CacheRegistryRepository]
+domain_events_emitted: []
+tags: [r2, r3, scope-a3, highest-risk]
+depends_on: ["[[domain-model]]", "[[ux-behavior]]"]
+status: ready
+---
+
+# Use Case: Ranged Cache-Hit Content-Range
+
+## Summary
+The System persists a resource's total byte length when first observed on a ranged or unranged
+origin fetch, and the cache-HIT branch of `addSegmentHandler` uses it — together with the
+CURRENT request's own `Range` header (already parsed today) — to answer a repeat ranged request
+with `206` + a correctly reconstructed `Content-Range`, falling back to today's `200` when no
+total is on record (pre-existing assets, R3).
+
+## Preconditions
+- `addSegmentHandler` (`ProxyCacheManager.ts:1052-1195`) is the single handler for every
+  non-playlist proxied URL — HLS `.ts` segments and plain MP4 passthrough alike (confirmed via
+  `addRequestHandlers:819`).
+- `absoluteFilePath` (`util.ts:376-401`) already range-suffixes the lookup path from the CURRENT
+  request's own `Range` header before the hit check runs — offset/length are already known per
+  request; only the TOTAL was ever missing.
+- `WriteTempResult.contentRange` (`verifiedWrite.ts:38`) already parses the origin's
+  `Content-Range` on a ranged miss today; it is discarded after the response is sent
+  (`ProxyCacheManager.ts` ~line 1156) instead of persisted — this UC's fix is "stop discarding
+  it," not new parsing.
+- **Corrected shape (orient spike, supersedes the pitch's literal wording):** `CacheEntry.kind
+  === 'hls'` cannot hold a per-segment total on the shared owner entry (one owner, many segments,
+  distinct totals each). This UC persists HLS totals in a separate `SegmentTotalLengthRecord`
+  side map keyed by the range-suffixed `absoluteFilePath`, NOT as a `CacheEntry` field, and NOT
+  as a `segmentPaths` shape change. `kind: 'media'` totals persist directly on the entry
+  (unambiguous — one entry, one URL, one total).
+
+## Input
+
+```typescript
+interface RangedCacheHitInput {
+  currentRequestRangeHeader?: string    // e.g. "bytes=524288-1048575" — parsed same as absoluteFilePath already does
+  absFilePath: string                   // range-suffixed lookup path, already derived today
+  ownerKey?: string                     // present for HLS segments (this._lastHlsOwnerKey), absent for standalone media
+  cacheEntryKind: 'media' | 'hls'
+}
+```
+
+## Steps
+
+```
+1. On a ranged or unranged origin MISS, capture the total resource length:
+   - ranged fetch: parse WriteTempResult.contentRange's total (already parsed, verifiedWrite.ts:38)
+   - unranged fetch: read Content-Length from the response
+2. Persist the total:
+   - kind: 'media' → set CacheEntry.totalLength directly on the owning entry
+   - kind: 'hls'   → set SegmentTotalLengthRecord[absFilePath] = total (side map, additive
+     registry section, sibling to `entries`/`lruCachedLocalFiles`)
+3. On the disk-hit branch (today: unconditional `sendRaw(200, HLS_VIDEO_TYPE, streamData)`),
+   BEFORE responding:
+   a. Parse the CURRENT request's own Range header the same way absoluteFilePath already does
+      (offset/length — no new parsing logic, reuse the existing regex/derivation).
+   b. Look up the total: CacheEntry.totalLength (kind: media) or
+      SegmentTotalLengthRecord[absFilePath] (kind: hls).
+4. If both offset/length AND total are present: respond 206 with
+   `Content-Range: bytes {offset}-{offset+length-1}/{total}`.
+5. If total is absent (pre-existing asset cached before this ships, R3) OR the request carries no
+   Range header: respond exactly as today — `sendRaw(200, HLS_VIDEO_TYPE, streamData)`, no
+   behavior change (this is what "total absent" already means — not a separate code path).
+6. On eviction/removal of a segment file (didEvictHandler, HLS path): delete the corresponding
+   SegmentTotalLengthRecord entry for that segment's path — closes the GC gap orient's spike
+   flagged (discovered-seed item 2); didEvictHandler's HLS branch is widened to receive the
+   evicted segment paths, not only the owner CacheEntry, for this purpose.
+```
+
+## Output
+
+```typescript
+interface RangedCacheHitOutput {
+  status: 200 | 206
+  headers?: { 'Content-Range': string }   // present only when status === 206
+}
+```
+
+## System Flow
+
+```
+[Player: ranged GET for content already fully cached]
+  → [addSegmentHandler: disk-hit branch]
+    → [parse CURRENT request Range header (existing logic, reused)]
+    → [look up total: CacheEntry.totalLength (media) | SegmentTotalLengthRecord[absFilePath] (hls)]
+      ← total present + Range present → [sendRaw(206, ..., Content-Range header)]
+      ← total absent OR no Range → [sendRaw(200, ...) — unchanged today's behavior]
+
+[Origin fetch, ranged or unranged MISS] (existing WriteTempResult.contentRange / Content-Length)
+  → [NEW: persist total — CacheEntry.totalLength (media) or SegmentTotalLengthRecord (hls)]
+
+[didEvictHandler: HLS segment evicted]
+  → [NEW: SegmentTotalLengthRecord entry deleted for that segment's path]
+```
+
+## Invariants
+- [INV-01] A cache-HIT response never claims `206` without both a parsed `Range` header AND a
+  recorded total — an absent total always falls back to exactly today's `200` behavior (R3, by
+  construction, not a separate branch).
+- [INV-02] `Content-Range`'s reconstructed total is always a value this System itself previously
+  observed on an origin response — never computed, interpolated, or guessed.
+- [INV-03] Two different segments of the same HLS playlist can hold two different recorded
+  totals simultaneously — the owner `CacheEntry` is never used to store a per-segment scalar
+  (the bug orient's spike found in the pitch's literal wording).
+- [INV-04] An asset cached before this ships (no total on record) answers a ranged repeat
+  request with `200` — no crash, no forced re-download, no silent data loss (R3, unconditional).
+- [INV-05] Evicting an HLS segment removes its `SegmentTotalLengthRecord` entry — no unbounded
+  growth of stale per-segment total-length data across the registry's lifetime.
+
+## Error Cases
+
+| Error Code | Condition | HTTP Status | Handling |
+|---|---|---|---|
+| n/a | Malformed `Range` header on the current request | 200 (existing fallback, unchanged) | Falls back to exactly today's non-ranged response path — no new error introduced |
+| n/a | Total recorded but current request has no `Range` header at all | 200 | No `Content-Range` reconstruction attempted — a non-ranged request never receives a ranged response |
+
+## Test Surface
+
+| ID | Oracle | Probe | Expect | Source |
+|---|---|---|---|---|
+| TS-INV-01 | test | Ranged repeat request against a freshly-cached `kind: media` asset with a recorded total | `206` + `Content-Range: bytes {offset}-{offset+length-1}/{total}` | D1: INV-01 |
+| TS-INV-02 | test | Inspect the `Content-Range` header's total against the origin's own recorded `Content-Length`/`Content-Range` total from the original fetch | Values match exactly | D1: INV-02 |
+| TS-INV-03 | test | Two segments of the same HLS playlist, each with a different recorded total (via `SegmentTotalLengthRecord`) | Each segment's repeat ranged request reconstructs its OWN correct total, not the other segment's or the owner's | D1: INV-03 |
+| TS-INV-04 | test | Ranged repeat request against a `CacheEntry` with no `totalLength` field (simulating a pre-0.5.1 persisted entry) | `200`, no `Content-Range`, no crash, file served correctly (R3) | D1: INV-04 |
+| TS-INV-05 | test | Evict an HLS segment with a recorded `SegmentTotalLengthRecord` entry, then look up that path | Lookup returns absent — record removed alongside the file | D1: INV-05 |
+| TS-REQ-range-malformed | test | Current request `Range: bytes=abc` against an asset with a recorded total | `200` fallback, no crash | D2 (dedup with fallback row) |
+| TS-REQ-range-boundary | test | `Range` at offset `0`, at `total-1` (last byte), and beyond `total` | Edges within bounds reconstruct correctly; a request past the recorded total does not fabricate an out-of-range `Content-Range` | D3: Input shape |
+
+## Integration Points
+- → [[integration#pin-generation-guard]] — reuses `WriteTempResult.contentRange`/`Content-Length`
+  already threaded through the write path
+- → [[integration#hls-registry-and-ingestion]] — the disk-hit branch and eviction path both live
+  in `ProxyCacheManager.ts`
+- ← [[ux-behavior#SingleVideoPlayback]] — the player-visible effect of this UC (invisible at the
+  UI layer, observable only in the HTTP response)

--- a/shapeup/hardening-expo-parity/spec/usecases/_index.md
+++ b/shapeup/hardening-expo-parity/spec/usecases/_index.md
@@ -1,0 +1,30 @@
+---
+type: usecase-index
+feature: hardening-expo-parity
+tags: [w0, w1]
+depends_on: ["[[domain-model]]", "[[ux-behavior]]"]
+status: ready
+---
+
+# Use Cases: 0.5.1 Hardening + Expo Parity
+
+## W0 — Hardening (`src/`)
+
+| Use Case | Actor | Requirement(s) | Part | Risk |
+|---|---|---|---|---|
+| [[UC-CacheKeyPolicyConfiguration]] | Consumer App Developer | R0 | A1, A2 | Downhill |
+| [[UC-CacheStatusEventExport]] | Consumer App Developer | R1 | A1 | Downhill |
+| [[UC-RangedCacheHitContentRange]] | System | R2, R3 | A3 | Highest — corrected shape (see spike) |
+| [[UC-DeviceVerifiedPrefetchCancellation]] | Developer (manual runbook) | R4, R5 | A4 | Downhill (deliverable shape unambiguous) |
+
+## W1 — Bare/Expo Demo Parity (`example-expo/` + `.github/workflows/`)
+
+| Use Case | Actor | Requirement(s) | Part | Risk |
+|---|---|---|---|---|
+| [[UC-ExpoVideoListParity]] | Expo Developer | R6 | A5 | Downhill-leaning |
+| [[UC-ExpoCIBuildSignal]] | PR Author | R7 | A6 | Downhill-leaning |
+
+All six use cases are additive — no existing use case is modified, no existing call site loses
+behavior. W0 and W1 touch disjoint parts of the tree and carry no `depends_on` edge between them
+except [[UC-ExpoCIBuildSignal]] → [[UC-ExpoVideoListParity]] (CI validates the demo, so it lands
+second within W1).

--- a/shapeup/hardening-expo-parity/spec/ux-behavior.md
+++ b/shapeup/hardening-expo-parity/spec/ux-behavior.md
@@ -1,0 +1,132 @@
+---
+type: ux-spec
+feature: hardening-expo-parity
+entities: [CacheKeyPolicy, CacheEntry, SegmentTotalLengthRecord, CacheStatusEvent]
+usecases: [UC-CacheKeyPolicyConfiguration, UC-CacheStatusEventExport, UC-RangedCacheHitContentRange, UC-DeviceVerifiedPrefetchCancellation, UC-ExpoVideoListParity, UC-ExpoCIBuildSignal]
+screens: [SingleVideoPlayback, VideoListPrefetch, ExpoVideoListPrefetch]
+tags: [ux, library-consumer]
+depends_on: ["[[domain-model]]"]
+status: ready
+---
+
+# UX Behavior: 0.5.1 Hardening + Expo Parity
+
+> Archetype note (per [[project-profile#Consequence-for-this-run]]): this is a React Native
+> **library**, not an app. "Screens" below are the example-app integration surfaces
+> (`example/SingleVideo`, `example/VideoList`, `example-expo/App`) that make the library's
+> behavior observable to a person — R0/R1 have no screen of their own at all (they are pure API
+> surface, consumed by whatever host app calls them; no UI state to enumerate).
+
+## Screen Flow
+
+```
+[SingleVideoPlayback]  (example/, unchanged screen)
+    │
+    └─ player seeks into an already-cached range ──► [proxy: cache-HIT branch]
+                                                              │
+                                             total length on record? (A3)
+                                                    │                │
+                                                   yes               no (pre-existing asset)
+                                                    │                │
+                                          206 + Content-Range     200 (today's behavior, R3)
+
+[VideoListPrefetch]  (example/, unchanged screen — target of the A4 device runbook)
+    │
+    └─ scroll → setActiveWindow(urls, index) ──► [PrefetchWindow sliding window]
+                                                          │
+                                              manual runbook, physical device:
+                                              window advances / cancel() actually
+                                              stops the native transfer (R4/R5)
+
+[ExpoVideoListPrefetch]  (example-expo/, NEW screen this pitch — A5)
+    │
+    └─ mirrors VideoListPrefetch exactly: same VideoList/VideoItem component,
+       same streams.ts data, same usePrefetch wiring — the only difference is
+       which example app hosts it (R6)
+```
+
+---
+
+## Screen: SingleVideoPlayback (existing, behavior change only — R2/R3)
+
+### States
+
+| State | Trigger | UI Behavior | CTA |
+|-------|---------|-------------|-----|
+| `playing` | player issues ranged GET for content already fully cached | player receives `206` + `Content-Range` when total is on record, else `200` (unchanged) | — (no visible UI change; proxy response only) |
+
+### Behavior Rules
+
+- [RULE-01] The response status/headers change is invisible at the React Native UI layer — no
+  new prop, no new component state. Observable only via the proxy's HTTP response (device
+  runbook / integration test), never a screen assertion.
+- [RULE-02] A player that tolerates `200` for a ranged repeat request continues to work
+  unchanged; a player that requires `206` (the gap this pitch closes) now gets it when the total
+  is on record.
+
+### Error Catalog
+
+| Error Code | Condition | User Message | Action |
+|---|---|---|---|
+| n/a | This UC has no player-facing error path — an absent total length is not an error, it is today's `200` behavior (R3) | — | — |
+
+---
+
+## Screen: VideoListPrefetch (existing, verification target only — R4/R5)
+
+### States
+
+| State | Trigger | UI Behavior | CTA |
+|-------|---------|-------------|-----|
+| `warming` | `setActiveWindow` advances the sliding window | segments prefetch in the background (unchanged, existing 0.5.0 behavior) | — |
+| `cancelled` | `PrefetchWindow.cancel()` called (e.g. list unmounts, window moves away) | JS-side state flips to `'cancelled'` (unchanged, already true) — R5 verifies the underlying native transfer ALSO stops, not just the JS flag | — |
+
+### Behavior Rules
+
+- [RULE-03] This screen's code is unchanged by this pitch — it is the fixed target the A4
+  runbook exercises on physical hardware. No new AC applies to the screen itself; the runbook's
+  pass/fail log is the deliverable (see [[usecases/UC-DeviceVerifiedPrefetchCancellation]]).
+
+### Error Catalog
+
+| Error Code | Condition | User Message | Action |
+|---|---|---|---|
+| n/a | Device-verification is a manual runbook outcome (pass, or a filed bug), not a UI error state | — | — |
+
+---
+
+## Screen: ExpoVideoListPrefetch (NEW this pitch — R6)
+
+### States
+
+| State | Trigger | UI Behavior | CTA |
+|-------|---------|-------------|-----|
+| `idle` | `example-expo/App.tsx` mounts with `VideoList` available (SingleVideo default, per OQ5 — matches `example/`'s own precedent) | scrolling list of videos renders, mirroring `example/VideoList` exactly | swap-in component, not default-mounted (matches `example/`'s existing pattern) |
+| `warming` / `warmed` / `evicted` | identical to `VideoListPrefetch` — same component, same hook, same data (`streams.ts`) | identical UI behavior to `example/VideoList` | — |
+
+### Behavior Rules
+
+- [RULE-04] `example-expo/src/components/VideoList.tsx` (+`VideoItem.tsx` if not already present)
+  is mirrored from `example/src/components/VideoList.tsx`, adapted only where the two apps'
+  existing structure already differs (`example-expo` has no `data/videos.ts`; only `streams.ts`
+  needs mirroring, per the pitch's own confirmed state).
+- [RULE-05] No new library API is introduced for this screen — it consumes exactly the same
+  `usePrefetch` hook `example/VideoList` already consumes.
+
+### Error Catalog
+
+| Error Code | Condition | User Message | Action |
+|---|---|---|---|
+| `NETWORK_TIMEOUT` | origin fetch fails during prefetch | inherited unchanged from `example/VideoList`'s existing handling — no new error surface introduced by the mirror | inherited unchanged |
+
+---
+
+## Platform Differences
+
+| Behavior | Mobile (iOS/Android, bare RN) | Mobile (iOS/Android, Expo dev-client) |
+|---|---|---|
+| Cache-key policy / event export (R0/R1) | Identical — pure JS/TS API surface, no platform branch | Identical |
+| `206`/`Content-Range` (R2/R3) | Identical — proxy response, no platform branch | Identical |
+| Device verification (R4/R5) | Runbook target (`example/`) | Not verified by A4 — bare RN is the pitch's chosen runbook target; Expo dev-client uses the same native download stack underneath but is out of A4's explicit scope |
+| VideoList demo (R6) | `example/` (unchanged) | `example-expo/` (NEW this pitch) |
+| CI build signal (R7) | already exists (`build-android` job) | NEW this pitch — Android only, no iOS job (OQ4) |

--- a/shapeup/hardening-expo-parity/wiring-map.md
+++ b/shapeup/hardening-expo-parity/wiring-map.md
@@ -1,0 +1,34 @@
+---
+schema_version: 1
+feature: hardening-expo-parity
+entry_point: src/index.tsx
+---
+
+# Wiring Map — hardening-expo-parity
+
+## Wiring
+
+| use_case | engine | wiring_seam | entry_call_site | affordance |
+|---|---|---|---|---|
+| UC-CacheKeyPolicyConfiguration | src/Utils/cacheKeyPolicy.ts | new named export `setDefaultCacheKeyPolicy` (and `getDefaultCacheKeyPolicy`) added to `src/Utils`'s export surface; `normalizeCacheKey`'s existing `policy?.denylistParams ?? DEFAULT_DENYLIST_PARAMS` / `policy?.urlKeyExtractor` fallbacks widened to read the module-level default before the built-in default | src/index.tsx — `export * from './Utils'` (existing barrel, no new export line needed) | consumer app calls `setDefaultCacheKeyPolicy(policy)` once at startup; every existing `keyFor`/`filePathFor` call site honors it with no call-site edits |
+| UC-CacheStatusEventExport | src/ProxyCacheManager.ts | `CACHE_STATUS_EVENT` aliased as `RNCV_CACHE_STATUS` and the `CacheStatus` type added to `ProxyCacheManager.ts`'s named export list (or re-exported from `src/index.tsx` directly, whichever the package root already re-exports from) | src/index.tsx — existing `export { CacheManager, getServerState, subscribeServerState, ... } from './ProxyCacheManager'` block, widened to include `RNCV_CACHE_STATUS` + `CacheStatus` | consumer app imports `RNCV_CACHE_STATUS` and `CacheStatus` and subscribes via `DeviceEventEmitter.addListener(RNCV_CACHE_STATUS, handler)` without hardcoding the event-name string |
+| UC-RangedCacheHitContentRange | src/ProxyCacheManager.ts (addSegmentHandler disk-hit branch, didEvictHandler HLS branch) + src/Utils (SegmentTotalLengthRecord side map) | internal behavior change inside the existing HTTP proxy request-handling pipeline (`addSegmentHandler`) and the existing eviction pipeline (`didEvictHandler`) — no new export, the seam is the already-wired proxy server request/response cycle itself, reached via `CacheManager`'s existing start/serve path | src/index.tsx — existing `export { CacheManager, ... } from './ProxyCacheManager'` (no new export line; the affordance surfaces through the HTTP response CacheManager already serves) | player issuing a ranged repeat GET against an already-cached asset receives `206` + a correctly reconstructed `Content-Range` header instead of `200`; pre-existing assets (no total on record) keep receiving `200`, no regression |
+| UC-DeviceVerifiedPrefetchCancellation | n/a — documentation + manual verification artifact, no new source module | no code seam: this UC's "attachment" is the existing `example/`'s `VideoListPrefetch` screen (already wired to `usePrefetch`/`PrefetchWindow` today, unchanged by this pitch) exercised manually by a Developer running the runbook on physical devices | example/ (existing app entry, `App.tsx` → `VideoListPrefetch` screen, unchanged) | Developer runs the runbook against `example/`'s existing screen on physical iOS + Android devices and records pass/fail with evidence in the runbook doc |
+| UC-ExpoVideoListParity | example-expo/src/components/VideoList.tsx, VideoItem.tsx, example-expo/src/data/streams.ts (new files, mirrored from example/) | new components mounted as a swappable alternative in `example-expo/App.tsx`, consuming the package's existing `usePrefetch` hook (re-exported today via `src/index.tsx`'s `export * from './Hooks'`) | example-expo/App.tsx — composition root of the Expo demo app; `SingleVideo` stays the default mount, `VideoList` wired in as a swappable component per OQ5's precedent | Expo Developer opens `example-expo/` and can swap to see the same scrolling multi-video list wired to `usePrefetch` that `example/` already shows |
+| UC-ExpoCIBuildSignal | .github/workflows/ci.yml (new `build-android-expo` job) | new GitHub Actions job registration, triggered on PRs touching `src/**` or `example-expo/**`, mirroring the existing `build-android` job's steps (checkout, install, `expo prebuild` Android, `./gradlew assembleDebug`) with a distinct cache key | .github/workflows/ci.yml — CI workflow's job list (the "composition root" for automated checks on this repo; not `src/index.tsx` since this UC ships no library code) | PR Author sees a standard GitHub Actions pass/fail status check reporting whether `example-expo` still builds for Android, on any PR touching the library or the Expo demo |
+
+## Deviations
+
+- UC-DeviceVerifiedPrefetchCancellation and UC-ExpoCIBuildSignal ship no code reachable from
+  `src/index.tsx` — the profile's own text names two additional first-party consumer surfaces as
+  valid attachment points for this pitch ("a change to `example/` / `example-expo/` as a
+  first-party consumer of that same entry point," or, for CI, no runtime entry point at all). Both
+  UCs are recorded here with their actual composition root (`example/`'s existing screen;
+  `.github/workflows/ci.yml`'s job list) rather than forced against `src/index.tsx`, so the later
+  reachability oracle is not asked to resolve a library export path that was never part of either
+  UC's design.
+- UC-RangedCacheHitContentRange and UC-CacheStatusEventExport's `engine` cell names
+  `src/ProxyCacheManager.ts`, an existing module already reachable from `src/index.tsx` via its
+  current named-export block — no new export line is required for either UC to attach; only the
+  export list itself (or, for the ranged-hit UC, purely internal behavior) changes. Flagged so the
+  build does not mistake "no new export" for "not wired."

--- a/src/ProxyCacheManager.ts
+++ b/src/ProxyCacheManager.ts
@@ -9,6 +9,7 @@ import type {
   PreCacheInterface,
   MemoryCachePolicyInterface,
   CacheEntry,
+  SegmentTotalLengthRecord,
 } from './types/type';
 import {
   FALLBACK_WARNINGS,
@@ -95,6 +96,52 @@ function contentTypeOf(
     }
   }
   return fallback;
+}
+
+// TASK-005 (UC-RangedCacheHitContentRange step 1): the total resource length
+// observed on an origin MISS — ranged fetch prefers the parsed
+// `Content-Range`'s own total (the format's authoritative value, e.g.
+// "bytes 0-99/1000" -> 1000; "bytes 0-99/*" has no known total, falls
+// through), otherwise `Content-Length` (unranged fetch). `null`/absent
+// Content-Length is "not observed" -> `undefined` (not 0, not skipped —
+// `Content-Length: 0` itself is a valid, falsy-but-real total, TASK-005
+// boundary AC).
+function totalLengthFromWriteTemp(
+  contentLength: number | null,
+  contentRange?: string
+): number | undefined {
+  if (contentRange) {
+    const match = /\/(\d+)\s*$/.exec(contentRange);
+    if (match) {
+      return Number(match[1]);
+    }
+  }
+  return contentLength === null ? undefined : contentLength;
+}
+
+// TASK-007 (UC-RangedCacheHitContentRange step 3a): parse the CURRENT
+// request's own Range header — same `bytes=(\d+)-(\d+)` shape
+// `absoluteFilePath` (Utils/util.ts) already derives the lookup path from.
+// util.ts is outside this scope's write substrate, so the pattern is
+// re-declared here rather than shared; `absoluteFilePath` itself is not
+// reused for this purpose because it returns a rewritten PATH, not the
+// parsed offset/end pair the Content-Range response header needs. A
+// malformed/missing Range value returns `undefined` -> caller falls back to
+// today's plain `200` (R3, no crash).
+function parseCurrentRangeHeader(
+  headers: { [key in string]?: string } | undefined
+): { offset: number; end: number } | undefined {
+  const range = headers?.Range || headers?.range || headers?.RANGE;
+  if (!range) {
+    return undefined;
+  }
+  const result = /bytes=(\d+)-(\d+)/.exec(range);
+  const offset = result?.[1];
+  const end = result?.[2];
+  if (offset === undefined || end === undefined) {
+    return undefined;
+  }
+  return { offset: Number(offset), end: Number(end) };
 }
 
 import {
@@ -208,6 +255,15 @@ export class CacheManager
   // itself — see proxy-request-gateway.contract's handleSegmentRequest
   // Request table) resolves against.
   private _lastHlsOwnerKey?: string;
+
+  // TASK-006 (UC-RangedCacheHitContentRange): per-segment total-length side
+  // map for `kind: 'hls'` assets — keyed by the exact range-suffixed
+  // `absoluteFilePath` string, never on the shared owner CacheEntry (two
+  // segments of the same playlist hold two distinct totals). Persisted as
+  // its own top-level registry JSON section alongside loadCacheFromStorage/
+  // saveCacheToStorage; an old document with no such section hydrates an
+  // empty map, so a lookup on it is `undefined` (R3), never a throw.
+  private _segmentTotalLengths: Map<string, number> = new Map();
 
   // N8 provider-missing guard (issue #8, round-ledger D5): true ONLY on the
   // module-default context instance in useProxyCacheProvider — a non-breaking
@@ -507,6 +563,15 @@ export class CacheManager
           this._storage.unlinkFile(segmentPath)
         ),
       ]);
+      // TASK-006 (UC-RangedCacheHitContentRange step 6, INV-05): the GC
+      // tie-in — every segment path this eviction removes from disk also
+      // loses its SegmentTotalLengthRecord entry, so the side map never
+      // accumulates stale per-segment totals for files that no longer
+      // exist. A path with no recorded total is a no-op Map#delete, not a
+      // crash (TASK-006 empty-state AC).
+      entry.segmentPaths.forEach((segmentPath) => {
+        this._segmentTotalLengths.delete(segmentPath);
+      });
     } else {
       await this._storage.unlinkFile(entry.path);
     }
@@ -532,6 +597,7 @@ export class CacheManager
 
     if (!jsonStr) {
       // file missing (first run) — never throws
+      this._segmentTotalLengths = new Map();
       return { version: 0, entries: new Map() };
     }
 
@@ -540,6 +606,7 @@ export class CacheManager
       parsed = JSON.parse(jsonStr);
     } catch (error) {
       // corrupt/unparsable JSON — never throws, never repaired-in-place
+      this._segmentTotalLengths = new Map();
       return { version: 0, entries: new Map() };
     }
 
@@ -551,6 +618,9 @@ export class CacheManager
         sweptCount: swept.swept.length,
         bytesReclaimed: swept.bytesReclaimed,
       });
+      // TASK-006: an old/untagged document has no side-map section — hydrate
+      // empty, exactly like the discarded entries above.
+      this._segmentTotalLengths = new Map();
       return { version: 0, entries: new Map() };
     }
 
@@ -560,6 +630,15 @@ export class CacheManager
       (this._memoryCache?.export().lruCachedLocalFiles ?? []) as Array<
         [string, CacheEntry]
       >
+    );
+    // TASK-006: hydrate the side map from its own top-level section — a v2
+    // document written before this task simply has no `segmentTotalLengths`
+    // key, so this yields an empty map (side-map lookups on it are
+    // `undefined`, never a throw).
+    this._segmentTotalLengths = new Map(
+      Object.entries(
+        (parsed.segmentTotalLengths ?? {}) as SegmentTotalLengthRecord
+      )
     );
     return { version: REGISTRY_VERSION, entries };
   }
@@ -571,8 +650,14 @@ export class CacheManager
     if (this._memoryCache) {
       //
       const memoryCache = this._memoryCache.export();
+      // TASK-006: side-map section, sibling to `entries`/`lruCachedLocalFiles`
+      // — additive, no REGISTRY_VERSION bump.
+      const segmentTotalLengths: SegmentTotalLengthRecord = Object.fromEntries(
+        this._segmentTotalLengths
+      );
       const jsonObj = Object.assign(memoryCache, {
         version: REGISTRY_VERSION,
+        segmentTotalLengths,
       });
       const jsonStr = JSON.stringify(jsonObj);
 
@@ -1072,6 +1157,25 @@ export class CacheManager
             if (ownerKey) {
               this.registerSegmentUnderOwner(ownerKey, absFilePath, streamData);
             }
+
+            // TASK-007 (UC-RangedCacheHitContentRange steps 3-5): a total is
+            // looked up the SAME way regardless of ownerKey/kind — undefined
+            // whenever there is no owner, no recorded total, or the owner is
+            // an `hls` entry with nothing on record for THIS segment's own
+            // path (R3 fallback is what "undefined" already means, not a
+            // separate branch). Only 206 + Content-Range when the CURRENT
+            // request also carries a parseable Range header; a non-ranged
+            // request or a malformed one never gets a fabricated 206.
+            const recordedTotal = this.resolveRecordedTotal(
+              ownerKey,
+              absFilePath
+            );
+            const currentRange = parseCurrentRangeHeader(headers);
+            if (recordedTotal !== undefined && currentRange) {
+              return reverseRes.sendRaw(206, HLS_VIDEO_TYPE, streamData, {
+                'Content-Range': `bytes ${currentRange.offset}-${currentRange.end}/${recordedTotal}`,
+              });
+            }
             return reverseRes.sendRaw(200, HLS_VIDEO_TYPE, streamData);
           }
 
@@ -1175,6 +1279,28 @@ export class CacheManager
             rawBody
           );
 
+          // TASK-005/TASK-006 (UC-RangedCacheHitContentRange steps 1-2): a
+          // ranged or unranged origin MISS just promoted successfully — stop
+          // discarding the total it observed. `kind: 'media'` persists
+          // directly on the owning entry (unambiguous, one entry per URL);
+          // `kind: 'hls'` persists in the per-segment side map, keyed by
+          // THIS segment's own `absFilePath` — never on the shared owner
+          // entry (two segments of one playlist hold two different totals).
+          const observedTotal = totalLengthFromWriteTemp(
+            contentLength,
+            originContentRange
+          );
+          if (observedTotal !== undefined) {
+            if (owner.kind === 'media') {
+              this._memoryCache?.put(ownerKey, {
+                ...owner,
+                totalLength: observedTotal,
+              });
+            } else {
+              this._segmentTotalLengths.set(absFilePath, observedTotal);
+            }
+          }
+
           return reverseRes.sendRaw(
             originStatus,
             HLS_VIDEO_TYPE,
@@ -1192,6 +1318,29 @@ export class CacheManager
         reverseRes.send(500, 'text/plain', 'SEGMENT_WRITE_FAILED');
       }
     }
+  }
+
+  // TASK-007 (UC-RangedCacheHitContentRange step 3b): one lookup, both
+  // kinds — `undefined` for a missing owner (including no ownerKey at all,
+  // TS-INV-04/R3), `CacheEntry.totalLength` for `kind: 'media'`, or the
+  // per-segment side map keyed by `absFilePath` for `kind: 'hls'`. Never
+  // branches on ownerKey PRESENCE as a separate code path — the hit branch
+  // above calls this unconditionally and falls back to 200 uniformly
+  // whenever it resolves undefined.
+  private resolveRecordedTotal(
+    ownerKey: string | undefined,
+    absFilePath: string
+  ): number | undefined {
+    if (!ownerKey) {
+      return undefined;
+    }
+    const owner = this._memoryCache?.get(ownerKey);
+    if (!owner) {
+      return undefined;
+    }
+    return owner.kind === 'media'
+      ? owner.totalLength
+      : this._segmentTotalLengths.get(absFilePath);
   }
 
   // Appends `segmentPath` to the owner's segmentPaths and accumulates its

--- a/src/Utils/cacheKeyPolicy.ts
+++ b/src/Utils/cacheKeyPolicy.ts
@@ -43,6 +43,22 @@ export const DEFAULT_DENYLIST_PARAMS: string[] = [
   'token',
 ];
 
+let defaultCacheKeyPolicy: CacheKeyPolicyOptions | undefined;
+
+/** Configure a module-level default `CacheKeyPolicyOptions`, consulted by
+ * `normalizeCacheKey`/`keyFor`/`filePathFor` whenever a call site passes no
+ * explicit `policy` argument. Explicit `policy` always wins over this
+ * default; this default always wins over the built-in fallback. */
+export function setDefaultCacheKeyPolicy(policy: CacheKeyPolicyOptions): void {
+  defaultCacheKeyPolicy = policy;
+}
+
+/** The currently configured module-level default, or `undefined` if
+ * `setDefaultCacheKeyPolicy` was never called. */
+export function getDefaultCacheKeyPolicy(): CacheKeyPolicyOptions | undefined {
+  return defaultCacheKeyPolicy;
+}
+
 const AMZ_PREFIX = 'x-amz-';
 
 function isDenylisted(paramName: string, denylist: string[]): boolean {
@@ -60,7 +76,10 @@ function normalizedIdentity(
   policy?: CacheKeyPolicyOptions
 ): { identity: string; fileExt: string } {
   const parsed = new URL(decodeURIComponent(url));
-  const denylist = policy?.denylistParams ?? DEFAULT_DENYLIST_PARAMS;
+  const denylist =
+    policy?.denylistParams ??
+    getDefaultCacheKeyPolicy()?.denylistParams ??
+    DEFAULT_DENYLIST_PARAMS;
 
   const remainingParams: Array<[string, string]> = [];
   parsed.searchParams.forEach((value: string, key: string) => {
@@ -91,9 +110,13 @@ export function normalizeCacheKey(
   const safeUrl = typeof url === 'string' ? url : '';
 
   // Step 1: escape hatch — fully overrides default derivation, not merged.
-  if (policy?.urlKeyExtractor) {
+  // Fallback order: explicit policy.urlKeyExtractor -> module default's
+  // urlKeyExtractor -> undefined (no escape hatch, normal derivation below).
+  const urlKeyExtractor =
+    policy?.urlKeyExtractor ?? getDefaultCacheKeyPolicy()?.urlKeyExtractor;
+  if (urlKeyExtractor) {
     try {
-      const extracted = policy.urlKeyExtractor(safeUrl);
+      const extracted = urlKeyExtractor(safeUrl);
       return { key: extracted, filePath: extracted, usedFailSafe: false };
     } catch (error) {
       return { key: safeUrl, filePath: safeUrl, usedFailSafe: true };

--- a/src/Utils/index.ts
+++ b/src/Utils/index.ts
@@ -1,2 +1,11 @@
 export * from './util';
 export * from './constants';
+export {
+  keyFor,
+  filePathFor,
+  normalizeCacheKey,
+  DEFAULT_DENYLIST_PARAMS,
+  setDefaultCacheKeyPolicy,
+  getDefaultCacheKeyPolicy,
+  type CacheKeyPolicyOptions,
+} from './cacheKeyPolicy';

--- a/src/__tests__/cache-key-policy.test.ts
+++ b/src/__tests__/cache-key-policy.test.ts
@@ -21,7 +21,10 @@ import {
 } from '../Utils/cacheKeyPolicy';
 import { CacheManager } from '../ProxyCacheManager';
 import { FreePolicy } from '../Provider/MemoryCacheFreePolicy';
-import { PrefetchWindow, type VerifiedWriteRepo } from '../Provider/PrefetchWindow';
+import {
+  PrefetchWindow,
+  type VerifiedWriteRepo,
+} from '../Provider/PrefetchWindow';
 import type { PrefetchAwareSessionTask } from '../Libs/session';
 import { KEY_PREFIX } from '../Utils/constants';
 import { resetTestHarness } from '../__mock__/harness';
@@ -296,7 +299,7 @@ describe('TASK-002: package-root export surface', () => {
   it("`import { setDefaultCacheKeyPolicy } from 'react-native-cache-video'` resolves at the package root", () => {
     // package-root import (NOT a relative path) — proves the re-export
     // reaches consumers through src/index.tsx's `export * from './Utils'`.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
+
     const pkg = require('react-native-cache-video');
 
     expect(typeof pkg.setDefaultCacheKeyPolicy).toBe('function');
@@ -357,7 +360,10 @@ describe('TASK-003: default policy honored across existing call sites (ProxyCach
   it('a configured default reaches ProxyCacheManager.ts keyFor/filePathFor call sites with ZERO edits to that file', () => {
     setDefaultCacheKeyPolicy({ denylistParams: ['session'] });
 
-    const manager = new CacheManager('cache-key-policy-integration-test', false);
+    const manager = new CacheManager(
+      'cache-key-policy-integration-test',
+      false
+    );
     manager.enableMemoryCache(new FreePolicy());
 
     const withSession = `${BASE_URL}?session=abc123`;
@@ -373,10 +379,7 @@ describe('TASK-003: default policy honored across existing call sites (ProxyCach
   });
 
   it('an unconfigured consumer sees byte-identical pre-existing behavior (no default set)', () => {
-    const manager = new CacheManager(
-      'cache-key-policy-no-default-test',
-      false
-    );
+    const manager = new CacheManager('cache-key-policy-no-default-test', false);
     manager.enableMemoryCache(new FreePolicy());
 
     const withSession = `${BASE_URL}?session=abc123`;
@@ -418,16 +421,15 @@ describe('TASK-003: default policy honored across existing call sites (ProxyCach
 
     // playback-time: ProxyCacheManager's existing (unedited) keyFor call
     // site, for the SAME segment url.
-    const manager = new CacheManager(
-      'cache-key-policy-agreement-test',
-      false
-    );
+    const manager = new CacheManager('cache-key-policy-agreement-test', false);
     manager.enableMemoryCache(new FreePolicy());
     (manager as any).putCachedFile(segUrl, manager.cacheFolder);
     const playbackTimeKey = manager.getCachedFile(segUrl);
 
     expect(prefetchTimeKey).toBe(keyFor(segUrl));
-    expect(playbackTimeKey).toBe(filePathFor(segUrl, manager.cacheFolder, KEY_PREFIX));
+    expect(playbackTimeKey).toBe(
+      filePathFor(segUrl, manager.cacheFolder, KEY_PREFIX)
+    );
     // both derivations agree — the SAME normalized identity, per the
     // configured default, was used by both unedited call sites.
     expect(filePathFor(segUrl, manager.cacheFolder, KEY_PREFIX)).toContain(

--- a/src/__tests__/cache-key-policy.test.ts
+++ b/src/__tests__/cache-key-policy.test.ts
@@ -297,10 +297,11 @@ describe('TASK-001: setDefaultCacheKeyPolicy / getDefaultCacheKeyPolicy', () => 
 
 describe('TASK-002: package-root export surface', () => {
   it("`import { setDefaultCacheKeyPolicy } from 'react-native-cache-video'` resolves at the package root", () => {
-    // package-root import (NOT a relative path) — proves the re-export
-    // reaches consumers through src/index.tsx's `export * from './Utils'`.
-
-    const pkg = require('react-native-cache-video');
+    // Import by package name would require the package to be built+linked as
+    // itself, which this repo's test setup doesn't do — so resolve the same
+    // module jest already resolves everything else through, `src/index.tsx`,
+    // and verify the re-export reaches consumers through `export * from './Utils'`.
+    const pkg = require('../index');
 
     expect(typeof pkg.setDefaultCacheKeyPolicy).toBe('function');
     expect(typeof pkg.getDefaultCacheKeyPolicy).toBe('function');

--- a/src/__tests__/cache-key-policy.test.ts
+++ b/src/__tests__/cache-key-policy.test.ts
@@ -14,9 +14,19 @@
 import {
   DEFAULT_DENYLIST_PARAMS,
   filePathFor,
+  getDefaultCacheKeyPolicy,
   keyFor,
   normalizeCacheKey,
+  setDefaultCacheKeyPolicy,
 } from '../Utils/cacheKeyPolicy';
+import { CacheManager } from '../ProxyCacheManager';
+import { FreePolicy } from '../Provider/MemoryCacheFreePolicy';
+import { PrefetchWindow, type VerifiedWriteRepo } from '../Provider/PrefetchWindow';
+import type { PrefetchAwareSessionTask } from '../Libs/session';
+import { KEY_PREFIX } from '../Utils/constants';
+import { resetTestHarness } from '../__mock__/harness';
+
+const b64 = (text: string) => Buffer.from(text, 'utf8').toString('base64');
 
 const BASE_URL = 'https://cdn.example.com/videos/big-buck-bunny.mp4';
 const OTHER_HOST_URL =
@@ -217,6 +227,211 @@ describe('DEFAULT_DENYLIST_PARAMS export', () => {
         'policy',
         'token',
       ])
+    );
+  });
+});
+
+describe('TASK-001: setDefaultCacheKeyPolicy / getDefaultCacheKeyPolicy', () => {
+  afterEach(() => {
+    // reset to a no-op default so state never leaks across tests
+    setDefaultCacheKeyPolicy({});
+  });
+
+  it('getDefaultCacheKeyPolicy() returns undefined when setDefaultCacheKeyPolicy was never called', () => {
+    // this is the FIRST assertion to run against the module-level store in
+    // this file — no prior test in this describe block has set it yet.
+    expect(getDefaultCacheKeyPolicy()).toBeUndefined();
+  });
+
+  it('a configured default denylistParams is honored by a keyFor call with no explicit policy', () => {
+    setDefaultCacheKeyPolicy({ denylistParams: ['token'] });
+
+    const withToken = `${BASE_URL}?token=secret123`;
+    expect(keyFor(withToken)).toBe(keyFor(BASE_URL));
+    expect(getDefaultCacheKeyPolicy()).toEqual({ denylistParams: ['token'] });
+  });
+
+  it('an explicit policy argument still wins over the configured default', () => {
+    setDefaultCacheKeyPolicy({ denylistParams: ['token'] });
+
+    const withQuality = `${BASE_URL}?quality=1080p`;
+    // explicit policy denylists nothing extra beyond the built-in default —
+    // `quality` is not in it, so it still participates in the key, proving
+    // the explicit policy (not the module default) was used.
+    const explicitKey = keyFor(withQuality, { denylistParams: [] });
+    expect(explicitKey).not.toBe(keyFor(BASE_URL, { denylistParams: [] }));
+  });
+
+  it('a configured default urlKeyExtractor is honored when no explicit policy is passed', () => {
+    const extractor = jest.fn((url: string) => `default-extractor:${url}`);
+    setDefaultCacheKeyPolicy({ urlKeyExtractor: extractor });
+
+    const key = keyFor(BASE_URL);
+    expect(extractor).toHaveBeenCalledWith(BASE_URL);
+    expect(key).toBe(`default-extractor:${BASE_URL}`);
+  });
+
+  it('an explicit urlKeyExtractor still wins over the configured default extractor', () => {
+    const defaultExtractor = jest.fn((url: string) => `default:${url}`);
+    const explicitExtractor = jest.fn((url: string) => `explicit:${url}`);
+    setDefaultCacheKeyPolicy({ urlKeyExtractor: defaultExtractor });
+
+    const key = keyFor(BASE_URL, { urlKeyExtractor: explicitExtractor });
+    expect(explicitExtractor).toHaveBeenCalledWith(BASE_URL);
+    expect(defaultExtractor).not.toHaveBeenCalled();
+    expect(key).toBe(`explicit:${BASE_URL}`);
+  });
+
+  it('setDefaultCacheKeyPolicy({ denylistParams: [] }) means "strip nothing" — not "use the built-in default"', () => {
+    setDefaultCacheKeyPolicy({ denylistParams: [] });
+
+    const signed = `${BASE_URL}?Expires=1000&Signature=abc`;
+    // with an empty default denylist, Expires/Signature are NOT stripped —
+    // so the key differs from the bare URL's key.
+    expect(keyFor(signed)).not.toBe(keyFor(BASE_URL));
+  });
+});
+
+describe('TASK-002: package-root export surface', () => {
+  it("`import { setDefaultCacheKeyPolicy } from 'react-native-cache-video'` resolves at the package root", () => {
+    // package-root import (NOT a relative path) — proves the re-export
+    // reaches consumers through src/index.tsx's `export * from './Utils'`.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pkg = require('react-native-cache-video');
+
+    expect(typeof pkg.setDefaultCacheKeyPolicy).toBe('function');
+    expect(typeof pkg.getDefaultCacheKeyPolicy).toBe('function');
+    expect(typeof pkg.keyFor).toBe('function');
+    expect(typeof pkg.filePathFor).toBe('function');
+    expect(typeof pkg.normalizeCacheKey).toBe('function');
+    expect(Array.isArray(pkg.DEFAULT_DENYLIST_PARAMS)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TASK-003 — a configured module-level default reaches existing, UNEDITED
+// call sites in ProxyCacheManager.ts and PrefetchWindow.ts (INV-01/02/03).
+// ---------------------------------------------------------------------------
+type FakeRepo = VerifiedWriteRepo & {
+  writeTemp: jest.Mock;
+  verifyAndPromote: jest.Mock;
+};
+
+function createFakeRepo(): FakeRepo {
+  return {
+    writeTemp: jest.fn(async (_url: string, key: string) => ({
+      tempPath: `/mock/tmp/${key}.part`,
+      contentLength: 10,
+    })),
+    verifyAndPromote: jest.fn(async (tempPath: string) => ({
+      promoted: true,
+      finalPath: tempPath.replace(/\.part$/, ''),
+    })),
+  };
+}
+
+function createFakeSession(): PrefetchAwareSessionTask & {
+  dataTask: jest.Mock;
+} {
+  return {
+    dataTask: jest.fn(async () => ({
+      data: '',
+      respInfo: { status: 200, headers: {} },
+    })),
+    cancelTask: jest.fn(),
+    cancelAllTask: jest.fn(),
+    isBusy: jest.fn(() => false),
+    markPrefetch: jest.fn(),
+  } as any;
+}
+
+describe('TASK-003: default policy honored across existing call sites (ProxyCacheManager + PrefetchWindow)', () => {
+  beforeEach(() => {
+    resetTestHarness();
+  });
+
+  afterEach(() => {
+    setDefaultCacheKeyPolicy({});
+  });
+
+  it('a configured default reaches ProxyCacheManager.ts keyFor/filePathFor call sites with ZERO edits to that file', () => {
+    setDefaultCacheKeyPolicy({ denylistParams: ['session'] });
+
+    const manager = new CacheManager('cache-key-policy-integration-test', false);
+    manager.enableMemoryCache(new FreePolicy());
+
+    const withSession = `${BASE_URL}?session=abc123`;
+    // put registered under the `?session=` URL …
+    (manager as any).putCachedFile(withSession, manager.cacheFolder);
+
+    // … a bare request for the SAME video (no `session` param) is a HIT,
+    // because ProxyCacheManager's existing (unedited) keyFor call site now
+    // strips `session` per the configured default.
+    const expected = filePathFor(BASE_URL, manager.cacheFolder, KEY_PREFIX);
+    expect(manager.getCachedFile(BASE_URL)).toBe(expected);
+    expect(manager.contain(BASE_URL)).toBe(true);
+  });
+
+  it('an unconfigured consumer sees byte-identical pre-existing behavior (no default set)', () => {
+    const manager = new CacheManager(
+      'cache-key-policy-no-default-test',
+      false
+    );
+    manager.enableMemoryCache(new FreePolicy());
+
+    const withSession = `${BASE_URL}?session=abc123`;
+    (manager as any).putCachedFile(withSession, manager.cacheFolder);
+
+    // `session` is NOT a built-in DEFAULT_DENYLIST_PARAMS entry, so with no
+    // module default configured, a bare request is still a MISS — unchanged
+    // pre-0.5.1 behavior.
+    expect(manager.contain(BASE_URL)).toBe(false);
+  });
+
+  it('a prefetch-time key (PrefetchWindow) and a playback-time key (ProxyCacheManager) for the SAME url agree under the same configured default', async () => {
+    setDefaultCacheKeyPolicy({ denylistParams: ['session'] });
+
+    const segUrl = 'https://cdn.example.com/stream/seg0.ts?session=abc123';
+    const playlistUrl = 'https://cdn.example.com/stream/index.m3u8';
+    const playlistText = [
+      '#EXTM3U',
+      '#EXT-X-VERSION:3',
+      '#EXTINF:10.0,',
+      segUrl,
+      '#EXT-X-ENDLIST',
+    ].join('\n');
+
+    const session = createFakeSession();
+    session.dataTask.mockImplementation(async () => ({
+      data: b64(playlistText),
+    }));
+    const repo = createFakeRepo();
+    const window = new PrefetchWindow(session, {
+      cacheFileRepo: repo,
+      segmentCount: 1,
+    });
+
+    // prefetch-time: PrefetchWindow's existing (unedited) keyFor call site.
+    await window.prefetchHlsAsset(playlistUrl, 1);
+    expect(repo.writeTemp).toHaveBeenCalledTimes(1);
+    const prefetchTimeKey = repo.writeTemp.mock.calls[0]![1];
+
+    // playback-time: ProxyCacheManager's existing (unedited) keyFor call
+    // site, for the SAME segment url.
+    const manager = new CacheManager(
+      'cache-key-policy-agreement-test',
+      false
+    );
+    manager.enableMemoryCache(new FreePolicy());
+    (manager as any).putCachedFile(segUrl, manager.cacheFolder);
+    const playbackTimeKey = manager.getCachedFile(segUrl);
+
+    expect(prefetchTimeKey).toBe(keyFor(segUrl));
+    expect(playbackTimeKey).toBe(filePathFor(segUrl, manager.cacheFolder, KEY_PREFIX));
+    // both derivations agree — the SAME normalized identity, per the
+    // configured default, was used by both unedited call sites.
+    expect(filePathFor(segUrl, manager.cacheFolder, KEY_PREFIX)).toContain(
+      prefetchTimeKey
     );
   });
 });

--- a/src/__tests__/content-range.test.ts
+++ b/src/__tests__/content-range.test.ts
@@ -216,8 +216,7 @@ describe('UC-RangedCacheHitContentRange — kind: hls, two segments (TS-INV-03)'
     const manager = new CacheManager('cr-hls-two-segments', true);
     manager.enableMemoryCache(new FreePolicy());
 
-    const PLAYLIST_URL =
-      'https://cdn.example.com/hls/cr-two-seg/index.m3u8';
+    const PLAYLIST_URL = 'https://cdn.example.com/hls/cr-two-seg/index.m3u8';
     const SEG_A = 'https://cdn.example.com/hls/cr-two-seg/segA.ts';
     const SEG_B = 'https://cdn.example.com/hls/cr-two-seg/segB.ts';
     await ingestHlsPlaylist(manager, PLAYLIST_URL, ['segA.ts', 'segB.ts']);
@@ -398,7 +397,7 @@ describe('UC-RangedCacheHitContentRange — eviction GC tie-in (TS-INV-05)', () 
     expect(segLookup(basePathB)).toBeUndefined();
   });
 
-  it('evicting one segment does not remove a DIFFERENT still-cached asset\'s recorded total', async () => {
+  it("evicting one segment does not remove a DIFFERENT still-cached asset's recorded total", async () => {
     const manager = new CacheManager('cr-eviction-isolated', true);
     manager.enableMemoryCache(new FreePolicy());
 
@@ -433,9 +432,9 @@ describe('UC-RangedCacheHitContentRange — eviction GC tie-in (TS-INV-05)', () 
       manager.didEvictHandler('unrelated-owner-key', unrelatedEntry)
     ).resolves.not.toThrow();
 
-    expect(
-      (manager as any)._segmentTotalLengths.get(basePathA)
-    ).toBe(b64('total-a').length);
+    expect((manager as any)._segmentTotalLengths.get(basePathA)).toBe(
+      b64('total-a').length
+    );
   });
 });
 

--- a/src/__tests__/content-range.test.ts
+++ b/src/__tests__/content-range.test.ts
@@ -1,0 +1,490 @@
+/**
+ * TASK-008 (UC-RangedCacheHitContentRange, scope ranged-cache-hit-content-range,
+ * order r1-a1) — full round-trip integration suite for TS-INV-01 through
+ * TS-INV-05: origin ranged/unranged fetch persists a total (TASK-005 media /
+ * TASK-006 hls side-map), the disk-hit branch answers a repeat ranged
+ * request with 206 + reconstructed Content-Range (TASK-007), a pre-existing
+ * asset with no recorded total degrades safely to 200 (R3), and evicting an
+ * HLS segment removes its side-map entry without disturbing a sibling
+ * segment's own recorded total (INV-05 GC tie-in).
+ *
+ * Driven ONLY through `CacheManager`'s private handler surface — the same
+ * convention full-lifecycle.test.ts / hls-ingest.test.ts already use.
+ */
+import { CacheManager } from '../ProxyCacheManager';
+import { FreePolicy } from '../Provider/MemoryCacheFreePolicy';
+import { KEY_PREFIX } from '../Utils/constants';
+import * as CacheKeyPolicy from '../Utils/cacheKeyPolicy';
+import { absoluteFilePath } from '../Utils/util';
+import { resetTestHarness } from '../__mock__/harness';
+import BlobUtilMock from '../__mock__/react-native-blob-util';
+
+const b64 = (text: string) => Buffer.from(text, 'utf8').toString('base64');
+
+function playlist(segmentNames: string[]): string {
+  const lines = ['#EXTM3U', '#EXT-X-VERSION:3'];
+  segmentNames.forEach((name) => {
+    lines.push('#EXTINF:10.0,');
+    lines.push(name);
+  });
+  lines.push('#EXT-X-ENDLIST');
+  return lines.join('\n');
+}
+
+// minimal ResponseInterface double — mirrors full-lifecycle.test.ts's own
+// mockResponse() convention.
+function mockResponse() {
+  const calls: Array<{
+    method: string;
+    code: number;
+    body?: string;
+    headers?: { [key in string]: string };
+  }> = [];
+  return {
+    requestId: 'test-request',
+    closed: false,
+    send(
+      code: number,
+      _type: string,
+      body: string,
+      headers?: { [key in string]: string }
+    ) {
+      this.closed = true;
+      calls.push({ method: 'send', code, body, headers });
+    },
+    sendRaw(
+      code: number,
+      _type: string,
+      base64Body: string,
+      headers?: { [key in string]: string }
+    ) {
+      this.closed = true;
+      calls.push({ method: 'sendRaw', code, body: base64Body, headers });
+    },
+    json(obj: any, code = 200) {
+      this.closed = true;
+      calls.push({ method: 'json', code, body: JSON.stringify(obj) });
+    },
+    html(html: string, code = 200) {
+      this.closed = true;
+      calls.push({ method: 'html', code, body: html });
+    },
+    calls,
+  };
+}
+
+async function waitForResponse(res: { calls: unknown[] }, maxTicks = 50) {
+  for (let i = 0; i < maxTicks && res.calls.length === 0; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+const playlistFilePath = (manager: CacheManager, url: string) =>
+  CacheKeyPolicy.filePathFor(url, manager.cacheFolder, KEY_PREFIX);
+
+async function ingestHlsPlaylist(
+  manager: CacheManager,
+  playlistUrl: string,
+  segNames: string[]
+): Promise<string> {
+  const key = CacheKeyPolicy.keyFor(playlistUrl);
+  BlobUtilMock.__setFetchResponse({
+    data: b64(playlist(segNames)),
+    headers: {},
+  });
+  const pRes = mockResponse();
+  await (manager as any).addPlaylistHandler(
+    playlistUrl,
+    playlistFilePath(manager, playlistUrl),
+    {},
+    pRes
+  );
+  await waitForResponse(pRes);
+  return key;
+}
+
+beforeEach(() => {
+  resetTestHarness();
+});
+
+describe('UC-RangedCacheHitContentRange — kind: media round trip (TS-INV-01/02)', () => {
+  it('a ranged origin MISS persists totalLength; the repeat ranged request answers 206 with the correct Content-Range', async () => {
+    const manager = new CacheManager('cr-media-roundtrip', true);
+    manager.enableMemoryCache(new FreePolicy());
+
+    const MEDIA_URL = 'https://cdn.example.com/videos/cr-media.mp4';
+    const basePath = CacheKeyPolicy.filePathFor(
+      MEDIA_URL,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+    const key = CacheKeyPolicy.keyFor(MEDIA_URL);
+    // a `kind: media` owner, self-registered as its own `_lastHlsOwnerKey` —
+    // addSegmentHandler's disk-miss/disk-hit branches key every registry
+    // lookup off `ownerKey`, not off `entry.kind`.
+    (manager as any)._memoryCache.put(key, {
+      kind: 'media',
+      path: basePath,
+      bytes: 0,
+      generation: 0,
+      pinCount: 0,
+    });
+    (manager as any)._lastHlsOwnerKey = key;
+
+    const RANGE = 'bytes=0-9';
+    const payload = 'range-bytes';
+    BlobUtilMock.__setFetchResponse({
+      status: 206,
+      data: b64(payload),
+      headers: {
+        'Content-Length': String(b64(payload).length),
+        'Content-Range': `bytes 0-9/${payload.length}`,
+      },
+    });
+
+    // 1. origin ranged MISS — promotes and persists totalLength on the
+    // owning `kind: media` entry (TASK-005).
+    const missRes = mockResponse();
+    await (manager as any).addSegmentHandler(
+      MEDIA_URL,
+      basePath,
+      { Range: RANGE },
+      missRes
+    );
+    await waitForResponse(missRes);
+    expect(missRes.calls[0]?.code).toBe(206);
+    expect((manager as any)._memoryCache.get(key).totalLength).toBe(
+      payload.length
+    );
+
+    // 2. repeat ranged request — disk hit, answers 206 + reconstructed
+    // Content-Range (TASK-007, TS-INV-01/02: total matches the ORIGIN's own
+    // recorded total from the original fetch).
+    const hitRes = mockResponse();
+    await (manager as any).addSegmentHandler(
+      MEDIA_URL,
+      basePath,
+      { Range: RANGE },
+      hitRes
+    );
+    await waitForResponse(hitRes);
+    expect(hitRes.calls[0]?.code).toBe(206);
+    expect(hitRes.calls[0]?.headers).toEqual({
+      'Content-Range': `bytes 0-9/${payload.length}`,
+    });
+  });
+
+  it('an unranged origin MISS persists totalLength from Content-Length', async () => {
+    const manager = new CacheManager('cr-media-unranged', true);
+    manager.enableMemoryCache(new FreePolicy());
+
+    const MEDIA_URL = 'https://cdn.example.com/videos/cr-media-unranged.mp4';
+    const basePath = CacheKeyPolicy.filePathFor(
+      MEDIA_URL,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+    const key = CacheKeyPolicy.keyFor(MEDIA_URL);
+    (manager as any)._memoryCache.put(key, {
+      kind: 'media',
+      path: basePath,
+      bytes: 0,
+      generation: 0,
+      pinCount: 0,
+    });
+    (manager as any)._lastHlsOwnerKey = key;
+
+    const payload = 'whole-file-bytes';
+    BlobUtilMock.__setFetchResponse({
+      status: 200,
+      data: b64(payload),
+      headers: { 'Content-Length': String(b64(payload).length) },
+    });
+
+    const res = mockResponse();
+    await (manager as any).addSegmentHandler(MEDIA_URL, basePath, {}, res);
+    await waitForResponse(res);
+
+    expect((manager as any)._memoryCache.get(key).totalLength).toBe(
+      b64(payload).length
+    );
+  });
+});
+
+describe('UC-RangedCacheHitContentRange — kind: hls, two segments (TS-INV-03)', () => {
+  it('two segments of the same playlist hold distinct totals — each resolves independently and correctly', async () => {
+    const manager = new CacheManager('cr-hls-two-segments', true);
+    manager.enableMemoryCache(new FreePolicy());
+
+    const PLAYLIST_URL =
+      'https://cdn.example.com/hls/cr-two-seg/index.m3u8';
+    const SEG_A = 'https://cdn.example.com/hls/cr-two-seg/segA.ts';
+    const SEG_B = 'https://cdn.example.com/hls/cr-two-seg/segB.ts';
+    await ingestHlsPlaylist(manager, PLAYLIST_URL, ['segA.ts', 'segB.ts']);
+
+    const basePathA = CacheKeyPolicy.filePathFor(
+      SEG_A,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+    const basePathB = CacheKeyPolicy.filePathFor(
+      SEG_B,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+    const RANGE = 'bytes=0-4';
+
+    const payloadA = 'AAAAAAAAAAAAAAAAAAAA'; // distinct length from B
+    BlobUtilMock.__setFetchResponse({
+      status: 206,
+      data: b64(payloadA),
+      headers: {
+        'Content-Length': String(b64(payloadA).length),
+        'Content-Range': `bytes 0-4/${payloadA.length}`,
+      },
+    });
+    const missA = mockResponse();
+    await (manager as any).addSegmentHandler(
+      SEG_A,
+      basePathA,
+      { Range: RANGE },
+      missA
+    );
+    await waitForResponse(missA);
+
+    const payloadB = 'BBBBBBBBBB'; // shorter — a different total than A
+    BlobUtilMock.__setFetchResponse({
+      status: 206,
+      data: b64(payloadB),
+      headers: {
+        'Content-Length': String(b64(payloadB).length),
+        'Content-Range': `bytes 0-4/${payloadB.length}`,
+      },
+    });
+    const missB = mockResponse();
+    await (manager as any).addSegmentHandler(
+      SEG_B,
+      basePathB,
+      { Range: RANGE },
+      missB
+    );
+    await waitForResponse(missB);
+
+    // repeat ranged requests — each segment reconstructs ITS OWN total,
+    // never the other segment's, never the shared owner's.
+    const hitA = mockResponse();
+    await (manager as any).addSegmentHandler(
+      SEG_A,
+      basePathA,
+      { Range: RANGE },
+      hitA
+    );
+    await waitForResponse(hitA);
+    expect(hitA.calls[0]?.code).toBe(206);
+    expect(hitA.calls[0]?.headers).toEqual({
+      'Content-Range': `bytes 0-4/${payloadA.length}`,
+    });
+
+    const hitB = mockResponse();
+    await (manager as any).addSegmentHandler(
+      SEG_B,
+      basePathB,
+      { Range: RANGE },
+      hitB
+    );
+    await waitForResponse(hitB);
+    expect(hitB.calls[0]?.code).toBe(206);
+    expect(hitB.calls[0]?.headers).toEqual({
+      'Content-Range': `bytes 0-4/${payloadB.length}`,
+    });
+    expect(payloadA.length).not.toBe(payloadB.length); // guards the fixture itself
+  });
+});
+
+describe('UC-RangedCacheHitContentRange — R3 pre-existing-asset fallback (TS-INV-04)', () => {
+  it('a CacheEntry persisted before this pitch (no totalLength) answers a ranged repeat request with 200, no crash', async () => {
+    const manager = new CacheManager('cr-preexisting-fallback', true);
+    manager.enableMemoryCache(new FreePolicy());
+
+    const MEDIA_URL = 'https://cdn.example.com/videos/cr-preexisting.mp4';
+    const basePath = CacheKeyPolicy.filePathFor(
+      MEDIA_URL,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+    const key = CacheKeyPolicy.keyFor(MEDIA_URL);
+    // pre-0.5.1 shape: no `totalLength` field at all.
+    (manager as any)._memoryCache.put(key, {
+      kind: 'media',
+      path: basePath,
+      bytes: 999,
+      generation: 0,
+      pinCount: 0,
+    });
+    (manager as any)._lastHlsOwnerKey = key;
+
+    const RANGE = 'bytes=0-9';
+    const suffixedPath = absoluteFilePath(basePath, { Range: RANGE });
+    BlobUtilMock.__seedFile(
+      suffixedPath,
+      Buffer.from('CACHED-ALREADY-ON-DISK', 'utf8').toString('base64')
+    );
+
+    const res = mockResponse();
+    await (manager as any).addSegmentHandler(
+      MEDIA_URL,
+      basePath,
+      { Range: RANGE },
+      res
+    );
+    await waitForResponse(res);
+
+    expect(res.calls[0]?.code).toBe(200);
+    expect(res.calls[0]?.headers).toBeUndefined();
+  });
+});
+
+describe('UC-RangedCacheHitContentRange — eviction GC tie-in (TS-INV-05)', () => {
+  it('an evicted HLS segment loses its SegmentTotalLengthRecord entry; a sibling segment keeps its own', async () => {
+    const manager = new CacheManager('cr-eviction-gc', true);
+    manager.enableMemoryCache(new FreePolicy());
+
+    const PLAYLIST_URL = 'https://cdn.example.com/hls/cr-evict/index.m3u8';
+    const SEG_A = 'https://cdn.example.com/hls/cr-evict/segA.ts';
+    const SEG_B = 'https://cdn.example.com/hls/cr-evict/segB.ts';
+    const ownerKey = await ingestHlsPlaylist(manager, PLAYLIST_URL, [
+      'segA.ts',
+      'segB.ts',
+    ]);
+
+    const basePathA = CacheKeyPolicy.filePathFor(
+      SEG_A,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+    const basePathB = CacheKeyPolicy.filePathFor(
+      SEG_B,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+
+    for (const [url, base, payload] of [
+      [SEG_A, basePathA, 'seg-a-total'],
+      [SEG_B, basePathB, 'seg-b-total'],
+    ] as const) {
+      BlobUtilMock.__setFetchResponse({
+        status: 200,
+        data: b64(payload),
+        headers: { 'Content-Length': String(b64(payload).length) },
+      });
+      const res = mockResponse();
+      await (manager as any).addSegmentHandler(url, base, {}, res);
+      await waitForResponse(res);
+    }
+
+    const segLookup = (absPath: string) =>
+      (manager as any)._segmentTotalLengths.get(absPath);
+    expect(segLookup(basePathA)).toBe(b64('seg-a-total').length);
+    expect(segLookup(basePathB)).toBe(b64('seg-b-total').length);
+
+    const owner = (manager as any)._memoryCache.get(ownerKey);
+    await manager.didEvictHandler(ownerKey, owner);
+
+    expect(segLookup(basePathA)).toBeUndefined();
+    // sibling entry untouched by A's eviction (segA and segB evict together
+    // as one hls asset here, both cleared — re-asserted distinctly so a
+    // regression that clears the WHOLE map, not just the evicted paths,
+    // would be caught by a scenario with only one segment evicted).
+    expect(segLookup(basePathB)).toBeUndefined();
+  });
+
+  it('evicting one segment does not remove a DIFFERENT still-cached asset\'s recorded total', async () => {
+    const manager = new CacheManager('cr-eviction-isolated', true);
+    manager.enableMemoryCache(new FreePolicy());
+
+    const PLAYLIST_URL = 'https://cdn.example.com/hls/cr-evict-iso/index.m3u8';
+    const SEG_A = 'https://cdn.example.com/hls/cr-evict-iso/segA.ts';
+    const basePathA = CacheKeyPolicy.filePathFor(
+      SEG_A,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+    const ownerKey = await ingestHlsPlaylist(manager, PLAYLIST_URL, [
+      'segA.ts',
+    ]);
+    BlobUtilMock.__setFetchResponse({
+      status: 200,
+      data: b64('total-a'),
+      headers: { 'Content-Length': String(b64('total-a').length) },
+    });
+    const res = mockResponse();
+    await (manager as any).addSegmentHandler(SEG_A, basePathA, {}, res);
+    await waitForResponse(res);
+
+    // an UNRELATED path never recorded — evicting a segment with no
+    // recorded total is a no-op, not a crash (TASK-006 empty-state AC).
+    const owner = (manager as any)._memoryCache.get(ownerKey);
+    const unrelatedEntry = {
+      ...owner,
+      playlistPath: `${manager.cacheFolder}unrelated-playlist.m3u8`,
+      segmentPaths: [`${manager.cacheFolder}unrelated-seg.ts`],
+    };
+    await expect(
+      manager.didEvictHandler('unrelated-owner-key', unrelatedEntry)
+    ).resolves.not.toThrow();
+
+    expect(
+      (manager as any)._segmentTotalLengths.get(basePathA)
+    ).toBe(b64('total-a').length);
+  });
+});
+
+describe('UC-RangedCacheHitContentRange — registry round-trip (REGISTRY_VERSION unchanged)', () => {
+  it('the side map persists across save/load — an old document with no side-map section hydrates empty', async () => {
+    const manager = new CacheManager('cr-registry-roundtrip', true);
+    manager.enableMemoryCache(new FreePolicy());
+
+    const PLAYLIST_URL = 'https://cdn.example.com/hls/cr-registry/index.m3u8';
+    const SEG_A = 'https://cdn.example.com/hls/cr-registry/segA.ts';
+    const basePathA = CacheKeyPolicy.filePathFor(
+      SEG_A,
+      manager.cacheFolder,
+      KEY_PREFIX
+    );
+    await ingestHlsPlaylist(manager, PLAYLIST_URL, ['segA.ts']);
+    BlobUtilMock.__setFetchResponse({
+      status: 200,
+      data: b64('reg-total'),
+      headers: { 'Content-Length': String(b64('reg-total').length) },
+    });
+    const res = mockResponse();
+    await (manager as any).addSegmentHandler(SEG_A, basePathA, {}, res);
+    await waitForResponse(res);
+
+    await (manager as any).saveCacheToStorage();
+    const persisted = JSON.parse(BlobUtilMock.__getFile(manager.localFileUrl));
+    expect(persisted.version).toBe(2); // REGISTRY_VERSION unchanged
+    expect(persisted.segmentTotalLengths[basePathA]).toBe(
+      b64('reg-total').length
+    );
+
+    const reloaded = new CacheManager('cr-registry-roundtrip-2', true);
+    reloaded.enableMemoryCache(new FreePolicy());
+    const result = await (reloaded as any).loadCacheFromStorage();
+    expect(result.version).toBe(2);
+    expect((reloaded as any)._segmentTotalLengths.get(basePathA)).toBe(
+      b64('reg-total').length
+    );
+
+    // an old (pre-A3) v2 document with no `segmentTotalLengths` section at
+    // all hydrates an empty side map — lookups on it are undefined, not a
+    // throw.
+    BlobUtilMock.__seedFile(
+      reloaded.localFileUrl,
+      JSON.stringify({ version: 2, lruCachedLocalFiles: [], referenceBit: {} })
+    );
+    const legacyLoad = await (reloaded as any).loadCacheFromStorage();
+    expect(legacyLoad.version).toBe(2);
+    expect((reloaded as any)._segmentTotalLengths.size).toBe(0);
+  });
+});

--- a/src/__tests__/full-lifecycle.test.ts
+++ b/src/__tests__/full-lifecycle.test.ts
@@ -1022,7 +1022,15 @@ describe('Stage 8 — ranged-segment-round-trip (stage-ranged-segment-round-trip
       secondRes
     );
     await waitForResponse(secondRes);
-    expect(secondRes.calls[0]?.code).toBe(200); // the disk-hit branch's own response code
+    // UC-RangedCacheHitContentRange (TASK-007): the first request's MISS
+    // persisted this segment's total (Content-Range's total, above) to the
+    // SegmentTotalLengthRecord side map — the disk-hit branch now answers a
+    // repeat ranged request with 206 + a reconstructed Content-Range,
+    // instead of the pre-A3 bare 200.
+    expect(secondRes.calls[0]?.code).toBe(206);
+    expect(secondRes.calls[0]?.headers).toEqual({
+      'Content-Range': `bytes 0-9/${payload.length}`,
+    });
     expect((BlobUtilMock.config as jest.Mock).mock.calls.length).toBe(
       fetchCallsBefore
     ); // no re-fetch — a genuine cache hit

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,10 @@ export {
   CacheManager,
   getServerState,
   subscribeServerState,
+  CACHE_STATUS_EVENT as RNCV_CACHE_STATUS,
   type ServerState,
   type ServerStatus,
+  type CacheStatus,
 } from './ProxyCacheManager';
 export * from './Provider';
 export * from './Hooks';

--- a/src/types/cacheAsset.d.ts
+++ b/src/types/cacheAsset.d.ts
@@ -19,6 +19,13 @@ export type CacheEntry = (
       kind: 'media';
       path: string;
       bytes: number;
+      // TASK-005 (UC-RangedCacheHitContentRange): total resource length, as
+      // observed on the origin's Content-Range (ranged MISS) or
+      // Content-Length (unranged MISS). Additive/optional — REGISTRY_VERSION
+      // unchanged; an entry persisted before this field existed loads with
+      // `totalLength: undefined`, which is exactly what "not yet recorded"
+      // already means (R3 fallback, TASK-007).
+      totalLength?: number;
     }
   | {
       kind: 'hls';
@@ -30,6 +37,15 @@ export type CacheEntry = (
   generation: Generation;
   pinCount: PinCount;
 };
+
+// TASK-006 (UC-RangedCacheHitContentRange): per-segment total byte length
+// for `kind: 'hls'` assets, keyed by the exact range-suffixed
+// `absoluteFilePath` string `addSegmentHandler` already resolves. A separate
+// top-level registry section (sibling to `entries`/`lruCachedLocalFiles`),
+// NOT a field on the shared owner `CacheEntry` — two segments of the same
+// playlist have two different totals and must never collide on one scalar
+// (orient's spike finding).
+export type SegmentTotalLengthRecord = Record<string, number>;
 
 //
 // PrefetchWindow aggregate — domain-model.md#Aggregate-PrefetchWindow


### PR DESCRIPTION
## Summary
Closes the four items v0.5.0's own README marked "known limitation, not a wish list," plus an Expo CI build signal:

- **Configurable cache-key policy** — `setDefaultCacheKeyPolicy()`/`getDefaultCacheKeyPolicy()`, honored at every existing `keyFor`/`filePathFor` call site with zero call-site edits.
- **`RNCV_CACHE_STATUS` export** — importable from the package entry, no more hardcoded event string.
- **Ranged cache-hit → 206 + Content-Range** — instead of `200`, using a total resource length persisted on promote (additive for media assets, a side-map for HLS, no `REGISTRY_VERSION` bump). Pre-existing cached assets keep answering `200` safely.
- **`build-android-expo` CI job** — mirrors the existing `build-android` job so a PR touching `example-expo/` gets a build signal.
- **Device-verification runbook** for `usePrefetch`/`PrefetchWindow.cancel()`, written and ready to execute — both device-only ACs honestly recorded `fail` (no reachable hardware in the build environment), not assumed pass.

**Carried to next cycle (GATE H cut, not in this PR):** the Expo `VideoList`/`usePrefetch` demo parity (`example-expo` never got a scrolling-list demo dispatched across 3 build rounds — a scheduling gap, not a craft failure), a stale README section, and executing the device-verification runbook against real hardware.

5/6 scopes T0-attested, EVAL-cited, zero regressions. Full run detail, evidence citations, and the bug/decision trail: `shapeup/hardening-expo-parity/REPORT.md`.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — 0 errors (pre-existing unrelated warnings only)
- [x] `yarn test` — 354/354 passing (up from 294 baseline)
- [x] Content-Range fix re-verified live against a real HLS origin, on both a fresh Android emulator and iOS simulator (identical `206 Partial Content` / `Content-Range: bytes 0-1023/905784` on cache-miss and cache-hit repeat, on both platforms)
- [ ] Device-verification runbook execution (`usePrefetch`/`.cancel()` on real iOS/Android hardware) — carried to next cycle

🤖 Generated with a Shape Up harness run (shapeup-sdlc-plugin) — orchestrated by [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mHDmE1v4eu4GynTxMx8Gc