### PR TITLE
fix(ios): let GCDWebServer skip the per-connection background task

### DIFF
--- a/ios/CacheVideoHttpProxy.mm
+++ b/ios/CacheVideoHttpProxy.mm
@@ -108,6 +108,8 @@ RCT_EXPORT_METHOD(start:(double) port
         if (serviceName != nil) {
             options[GCDWebServerOption_BonjourName] = serviceName;
         }
+        options[GCDWebServerOption_DisableBackgroundTask] = @YES;
+
 
         NSError* error = nil;
         if ([_webServer startWithOptions:options error:&error]) {

--- a/ios/GCDWebServer/GCDWebServer/Core/GCDWebServer.h
+++ b/ios/GCDWebServer/GCDWebServer/Core/GCDWebServer.h
@@ -210,6 +210,12 @@ extern NSString* const GCDWebServerOption_DispatchQueuePriority;
  */
 extern NSString* const GCDWebServerOption_AutomaticallySuspendInBackground;
 
+/**
+ *  Enables the GCDWebServer to not create a background task when connections are open.
+ *  This prevents termination risk by iOS when the app goes to the background.
+ */
+extern NSString* const GCDWebServerOption_DisableBackgroundTask;
+
 #endif
 
 /**

--- a/ios/GCDWebServer/GCDWebServer/Core/GCDWebServer.m
+++ b/ios/GCDWebServer/GCDWebServer/Core/GCDWebServer.m
@@ -66,6 +66,7 @@ NSString* const GCDWebServerOption_ConnectedStateCoalescingInterval = @"Connecte
 NSString* const GCDWebServerOption_DispatchQueuePriority = @"DispatchQueuePriority";
 #if TARGET_OS_IPHONE
 NSString* const GCDWebServerOption_AutomaticallySuspendInBackground = @"AutomaticallySuspendInBackground";
+NSString* const GCDWebServerOption_DisableBackgroundTask = @"DisableBackgroundTask";
 #endif
 
 NSString* const GCDWebServerAuthenticationMethod_Basic = @"Basic";
@@ -230,7 +231,8 @@ static void _ExecuteMainThreadRunLoopSources() {
   GWS_LOG_DEBUG(@"Did connect");
 
 #if TARGET_OS_IPHONE
-  if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground) {
+  BOOL disableBackgroundTask = [(NSNumber*)_GetOption(_options, GCDWebServerOption_DisableBackgroundTask, @NO) boolValue];
+  if (!disableBackgroundTask && [[UIApplication sharedApplication] applicationState] != UIApplicationStateBackground) {
     [self _startBackgroundTask];
   }
 #endif


### PR DESCRIPTION
## Summary
Every connection to the local caching proxy's `GCDWebServer` spun up an iOS background task in `_didConnect` regardless of app state. Long HLS segment transfers routinely outlive the ~30s grace window, surfacing `"Background Task N ... was created over 30 seconds ago"` termination-risk warnings in the Expo example even while the app is foregrounded and actively playing (`x36xhzz` HLS asset, iOS simulator).

- Adds `GCDWebServerOption_DisableBackgroundTask` (default `NO`, so existing `GCDWebServer` consumers are unaffected).
- Opts `CacheVideoHttpProxy`'s server into it — this loopback proxy doesn't need iOS's background-task grace period to keep serving; playback backgrounding is handled at the player/audio-session level, not here.

## Test plan
- [x] Verified against the reported warning trace (Expo example, iOS simulator, `x36xhzz` HLS asset)
- [ ] Re-run the simulator playback session to confirm the warning no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mHDmE1v4eu4GynTxMx8Gc