### PR TITLE
chore(release): 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-cache-video",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "support cache video type mp4, mov, hls for cdn-preload-cached video in scrollview, flatlist",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary
Version bump for the release combining #24, #25, #26:
- Configurable cache-key policy (`setDefaultCacheKeyPolicy`/`getDefaultCacheKeyPolicy`)
- `RNCV_CACHE_STATUS` export
- Ranged cache-hit now answers `206` + `Content-Range` (was `200`)
- Android downloads stream to disk via native OkHttp (fixes truncation above 8 KB)
- iOS `GCDWebServer` no longer spins up a background task per connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mHDmE1v4eu4GynTxMx8Gc